### PR TITLE
Add new features introduced in Unit 1.2

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -253,6 +253,12 @@ The common options are follows:
     * - ``type``
       - Type of the application: ``go``, ``perl``, ``php``, ``python``,
         or ``ruby``.
+        You can also define a specific version number of the interpreter
+        that will be used to run the application.
+        Valid version formats are ``MAJOR``, ``MAJOR.MINOR``, and
+        ``MAJOR.MINOR.REVISION``.
+        When one of the first two formats is used, Unit will use
+        the latest ``MAJOR.MINOR.REVISION`` version found in existing modules.
 
     * - ``processes`` (optional)
       - Number of application processes.
@@ -270,8 +276,35 @@ The common options are follows:
       - Group name that runs the app process.
         If not specified, user's primary group is used.
 
-Depending on the ``type`` of application you need to configure a number of
-additional options.
+    * - ``environment`` (optional)
+      - Environment variables to be used by the application.
+
+Example::
+
+    {
+        "type": "python 3.6",
+        "processes": {
+            "max": 3,
+            "spare": 1
+        },
+        "working_directory": "/www/python-apps",
+        "path": "blog",
+        "module": "blog.wsgi",
+        "user": "blog",
+        "group": "blog",
+
+        "environment": {
+            "DJANGO_SETTINGS_MODULE": "blog.settings.prod",
+            "DB_ENGINE": "django.db.backends.postgresql",
+            "DB_NAME": "blog",
+            "DB_HOST": "127.0.0.1",
+            "DB_PORT": "5432"
+        }
+    }
+
+Depending on the ``type`` of the application, you may need to configure
+a number of additional options.
+In the example above, Python-specific options ``path`` and ``module`` are used.
 
 Go Application
 ==============
@@ -286,6 +319,11 @@ Go Application
       - Path to compiled application, absolute or relative
         to ``working_directory``.
 
+    * - ``arguments`` (optional)
+      - Command line arguments to be passed to the application.
+        The example below is equivalent to
+        ``/www/chat/bin/chat_app --tmp-files /tmp/go-cache``
+
 Example::
 
     {
@@ -293,7 +331,8 @@ Example::
         "working_directory": "/www/chat",
         "executable": "bin/chat_app",
         "user": "www-go",
-        "group": "www-go"
+        "group": "www-go",
+        "arguments": ["--tmp-files", "/tmp/go-cache"]
     }
 
 Perl Application
@@ -338,6 +377,25 @@ PHP Application
       - File that Unit runs for every URL, instead of searching for a file in
         the filesystem.  The location is relative to the root.
 
+You can also customize php.ini using the following options
+(available in the ``options`` object):
+
+.. list-table::
+    :header-rows: 1
+
+    * - Object
+      - Description
+
+    * - ``file`` (optional)
+      - Path to the php.ini file.
+
+    * - ``admin`` and ``user`` (optional)
+      - Hold the php.ini configuration options.
+        Note that the configuration values must be defined as strings,
+        even when they represent numbers.
+        The ``user`` object allows ``ini_set()`` to override the options
+        from within the application.
+
 Example::
 
     {
@@ -346,7 +404,19 @@ Example::
         "root": "/www/blogs/scripts",
         "index": "index.php",
         "user": "www-blogs",
-        "group": "www-blogs"
+        "group": "www-blogs",
+
+        "options": {
+            "file": "/etc/php.ini",
+            "admin": {
+                "memory_limit": "256M",
+                "variables_order": "EGPCS",
+                "expose_php": "0"
+            },
+            "user": {
+                "display_errors": "0"
+            }
+        }
     }
 
 Python Application

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -263,6 +263,8 @@ The common options are follows:
     * - ``processes`` (optional)
       - Number of application processes.
         By default 1 process is used.
+        Use the ``max`` and ``spare`` options to take advantage of
+        the dynamic processes management feature.
 
     * - ``working_directory`` (optional)
       - Working directory for the application.

--- a/source/index.rst
+++ b/source/index.rst
@@ -18,7 +18,7 @@ Key Features
 
 - Fully dynamic reconfiguration using RESTful JSON API
 - Multiple application languages and versions can run simultaneously
-- Dynamic application processes management *(coming soon)*
+- Dynamic application processes management
 - TLS support *(coming soon)*
 - TCP, HTTP, HTTPS, HTTP/2 routing and proxying *(coming soon)*
 


### PR DESCRIPTION
References:
1. https://mailman.nginx.org/pipermail/unit/2018-June/000055.html
2. https://www.nginx.com/blog/nginx-unit-1-2-release-available-now/

Additionally, this commit adds an explanation about the ability to define
a specific version of the language interpreter that will be used
to run the application.
This behavior is explained in [issue #46](https://github.com/nginx/unit/issues/46#issuecomment-331673060).