### PR TITLE
Ruby "working_directory" with unit 1.2 and up

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -659,6 +659,16 @@ Example::
         "group": "www",
         "script": "/www/cms/config.ru"
     }
+    
+Example::
+{
+        "type": "ruby",
+        "processes": 5,
+        "user": "www",
+        "group": "www",
+        "working_directory":"/www/cms",
+        "script": "/www/cms/config.ru"
+}    
 
 Access log
 **********


### PR DESCRIPTION
After version 1.1 you must add "working_directory" directive in your ruby application configuration :

Example::
{
        "type": "ruby",
        "processes": 5,
        "user": "www",
        "group": "www",
        "working_directory":"/www/cms",
        "script": "/www/cms/config.ru"
}