### PR TITLE
Fix a missing curly brace in the Redmine Howto

### DIFF
--- a/source/howto/redmine.rst
+++ b/source/howto/redmine.rst
@@ -43,8 +43,9 @@ Redmine
                   "environment": {
                       "RAILS_ENV": ":nxt_term:`production<Environment name in Redmine config>`"
                   }
-           }
-       }
+              }
+          }
+      }
 
    See :ref:`Ruby application options <configuration-ruby>` for details.
 


### PR DESCRIPTION
Hello everyone,

Currently, a missing curly brace leads to the validation error when following the [Redmine Howto](https://unit.nginx.org/howto/redmine/).
```json
{
        "error": "Invalid JSON.",
        "detail": "Unexpected end of JSON payload.  There's an object without a closing brace (}).",
        "location": {
                "offset": 388,
                "line": 19,
                "column": 1
        }
}
```

So this PR fixes that.
It also fixes indentation for a couple of other curly braces.

Best regards!