### PR TITLE
Drupal's update.php needs workaround

### DIFF
--- a/source/howto/drupal.rst
+++ b/source/howto/drupal.rst
@@ -87,7 +87,8 @@ Unit:
                           "/core/modules/statistics/statistics.php",
                           "~^/core/modules/system/tests/https?\\.php",
                           "/core/rebuild.php",
-                          "/update.php"
+                          "/update.php",
+                          "/update.php/*"
                       ]
                   },
 


### PR DESCRIPTION
There's no way to run updates because it using `/update.php/selection` and then `/update.php/start` and `/results`