### PR TITLE
Change dark mode styles for better contrast, links in light mode

### DIFF
--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -13,6 +13,9 @@ pre {
 a {
     color: #333;
 }
+#content a {
+    color: revert;
+}
 a:hover {
     text-decoration: none;
 }
@@ -776,6 +779,16 @@ iframe {
     }
     a {
         color: #cbd5e1;
+    }
+    #content a {
+        color: #8cb4ff;
+    }
+    #content .literal,
+    #content span.option {
+        background: #343434;
+        color: rgb(255, 255, 255);
+        padding: .125rem .25rem;
+        border-radius: 0.25em;
     }
     .nxt_github_link div {
         filter: invert(1);

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -249,7 +249,8 @@ iframe {
 }
 #content .literal,
 #content span.option {
-    padding: .2em .4em;
+    padding: .125rem .25rem;
+    border-radius: 0.25em;
     background: #eee;
     color: #666;
     white-space: nowrap;
@@ -787,8 +788,6 @@ iframe {
     #content span.option {
         background: #343434;
         color: rgb(255, 255, 255);
-        padding: .125rem .25rem;
-        border-radius: 0.25em;
     }
     .nxt_github_link div {
         filter: invert(1);

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -787,7 +787,7 @@ iframe {
     #content .literal,
     #content span.option {
         background: #343434;
-        color: rgb(255, 255, 255);
+        color: #FFFFFF;
     }
     .nxt_github_link div {
         filter: invert(1);


### PR DESCRIPTION
# What

## Dark Mode Changes
This change makes changes to the dark mode presentation of the site to increase readability.
It does so by:
*  Changing the styles on inline code literals to differ from the white text around them. Also adds a slight border radius to these elements to help them flow inline with the text.
* Changes the link styling to be closer to browser default, but with small color changes to take into account the background color

These changes are heavily based on the dark mode presentation of https://developer.mozilla.org/en-US/

### Dark Mode before this change:
![Screenshot 2023-09-21 at 4 10 10 PM](https://github.com/nginx/unit-docs/assets/785331/28ebe474-021d-4f29-bc94-66f05914fad9)

### Dark Mode after this change
![Screenshot 2023-09-21 at 3 42 35 PM](https://github.com/nginx/unit-docs/assets/785331/74a47c49-0042-449b-a451-ccd0d0c85d90)

## Light Mode changes
Changes the link presentation on light mode to browser default in keeping with the [general practice of having a contrast between text and links](https://webaim.org/articles/contrast/#only)

Also adds the rounded corners change from dark mode.

### Light Mode before this change
![Screenshot 2023-09-21 at 4 10 22 PM](https://github.com/nginx/unit-docs/assets/785331/c92a14f3-439e-4a36-81f5-a279a61233e0)

### Light Mode after this change

![Screenshot 2023-09-21 at 4 27 42 PM](https://github.com/nginx/unit-docs/assets/785331/eadaea50-196e-4e3e-9654-8fabaff6fde0)

