### PR TITLE
make compatible with sphinx 7.x

### DIFF
--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -37,7 +37,7 @@
          url('{{ pathto('_static/OpenSans.woff', 1) + '?' + md5('theme/static/OpenSans.woff') }}') format('woff');
 }
 </style>
-<link rel="stylesheet" href="{{ pathto('_static/' + style, 1) + '?' + md5('theme/static/' + style) }}" />
+<link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) + '?' + md5('theme/static/' + styles[-1]) }}" />
 <link rel="icon" href="{{ pathto('_static/icon.png', 1) + '?' + md5('theme/static/icon.png') }}" />
 <link rel="alternate" type="application/rss+xml" title="Subscribe to NGINX Unit News" href="{{ nxt_baseurl + nxt_rss_file }}" />
 <script async src="{{ pathto('_static/script.js', 1) + '?' + md5('theme/static/script.js') }}"></script>


### PR DESCRIPTION
# What
In Sphinx 7.x the `style` key for HTML templates [was removed ](https://github.com/sphinx-doc/sphinx/pull/11381).

In this theme, since we just have one stylesheet (as far as I can tell) revert to using `styles`. Based on [my spelunking](https://github.com/AA-Turner/sphinx/blob/ec993dda3690f260345133c47a4a0f6ef0b18493/doc/development/templating.rst) This should also be compatible with 6.x versions.


## Notes
I'm not a Python Dude ™️ so it's possible I did the Python wrong.  Please correct me