### PR TITLE
Remove unnecessary semicolons from Go example

### DIFF
--- a/source/howto/samples.rst
+++ b/source/howto/samples.rst
@@ -20,8 +20,8 @@ Let's configure the following basic app, saved as :file:`/www/app.go`:
    package main
 
    import (
-       "io";
-       "net/http";
+       "io"
+       "net/http"
        "unit.nginx.org/go"
    )
 


### PR DESCRIPTION
These semicolons in the Go example are ineffectual and should be removed.