### PR TITLE
Add details of non-matching mime type filter behaviour

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2606,11 +2606,11 @@ when a 40x response would be returned.
         }
     }
 
-Here, all requests to images, fonts, and any text based files will have
+Here, all requests to images, fonts, and any text-based files will have
 a cache control header added to the response. Any other requests will still
 serve the files, but this time without the header. This is useful
 for serving common web page resources that do not change; web browsers
-and proxies are informed this content should be cached.
+and proxies are informed that this content should be cached.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2609,8 +2609,8 @@ when a 40x response would be returned.
 Here, all requests to images, fonts, and any text based files will have
 a cache control header added to the response. Any other requests will still
 serve the files, but this time without the header. This is useful
-for serving common web page resources that do not change with cache
-while letting other files to bypass cache.
+for serving common web page resources that do not change; web browsers
+and proxies are informed this content should be cached.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2588,27 +2588,29 @@ Additionally, the :file:`.3gpp` and :file:`.3gpp2` file types
 are allowed by a
 :ref:`regex pattern <configuration-routes-matching-patterns>`.
 
-If none MIME types match the request, a 403 "Forbidden" response is
+If no MIME types match the request, a 403 "Forbidden" response is
 returned. You can pair that behaviour with a 
 :ref:`fallback <configuration-fallback>` option that will be called
-if the :samp:`share` rules would return a 40x.
+when the a 40x response would be returned.
 
 .. code-block:: json
 
     {
-        "share": "/www/data$uri",
-        "types": ["application/pdf", "image/*", "font/*", "text/plain"],
+        "share": "/www/data/static$uri",
+        "types": ["image/*", "font/*", "text/*"],
         "response_headers": {
             "Cache-Control": "max-age=1209600"
         },
         "fallback": {
-            "share": "/www/data$uri"
+            "share": "/www/data/static$uri",
         }
     }
 
-Here, all requests to :samp:`.pdf` files, all images, all fonts, and all
-plain text files will have a cache control header added to them. Any other
-requests will still serve the file, but this time without the header.
+Here, all requests to images, fonts, and plain text files will have 
+a cache control header added to them. Any other requests will still
+serve the files, but this time without the header. This is useful
+for serving common web page resources that do not change with cache
+while letting other files to bypass cache.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2591,7 +2591,7 @@ are allowed by a
 If no MIME types match the request, a 403 "Forbidden" response is
 returned. You can pair that behaviour with a 
 :ref:`fallback <configuration-fallback>` option that will be called
-when the a 40x response would be returned.
+when a 40x response would be returned.
 
 .. code-block:: json
 
@@ -2606,8 +2606,8 @@ when the a 40x response would be returned.
         }
     }
 
-Here, all requests to images, fonts, and plain text files will have 
-a cache control header added to them. Any other requests will still
+Here, all requests to images, fonts, and any text based files will have
+a cache control header added to the response. Any other requests will still
 serve the files, but this time without the header. This is useful
 for serving common web page resources that do not change with cache
 while letting other files to bypass cache.

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2588,24 +2588,27 @@ Additionally, the :file:`.3gpp` and :file:`.3gpp2` file types
 are allowed by a
 :ref:`regex pattern <configuration-routes-matching-patterns>`.
 
-If none of the share rules for a given MIME type of a request match,
-the response is going to have a status of 403 Forbidden. You can pair
-that behaviour with a :ref:`fallback <configuration-fallback>` option
-that will be called if the :samp:`share` rules would return a 40x.
+If none MIME types match the request, a 403 "Forbidden" response is
+returned. You can pair that behaviour with a 
+:ref:`fallback <configuration-fallback>` option that will be called
+if the :samp:`share` rules would return a 40x.
 
 .. code-block:: json
 
     {
-        "share": "/www/data",
-        "types": [ "!application/x-httpd-php" ],
-
+        "share": "/www/data$uri",
+        "types": ["application/pdf", "image/*", "font/*", "text/plain"],
+        "response_headers": {
+            "Cache-Control": "max-age=1209600"
+        },
         "fallback": {
-            "pass": "applications/php"
+            "share": "/www/data$uri"
         }
     }
 
-Here, all requests to existing files other than :samp:`".php"` will be
-served as static content while the rest will be passed to a PHP application.
+Here, all requests to :samp:`.pdf` files, all images, all fonts, and all
+plain text files will have a cache control header added to them. Any other
+requests will still serve the file, but this time without the header.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2588,6 +2588,25 @@ Additionally, the :file:`.3gpp` and :file:`.3gpp2` file types
 are allowed by a
 :ref:`regex pattern <configuration-routes-matching-patterns>`.
 
+If none of the share rules for a given MIME type of a request match,
+the response is going to have a status of 403 Forbidden. You can pair
+that behaviour with a :ref:`fallback <configuration-fallback>` option
+that will be called if the :samp:`share` rules would return a 40x.
+
+.. code-block:: json
+
+    {
+        "share": "/www/data",
+        "types": [ "!application/x-httpd-php" ],
+
+        "fallback": {
+            "pass": "applications/php"
+        }
+    }
+
+Here, all requests to existing files other than :samp:`".php"` will be
+served as static content while the rest will be passed to a PHP application.
+
 If the MIME type of a requested file isn't recognized,
 it's considered empty
 (:samp:`""`).


### PR DESCRIPTION
Closes #63 

* Adds details to main configuration documentation on what happens to mime type filtering when a request's mime type is not matched by any of the rules in the share option.
* Lifts example from the 1.24.0 news item for usage with a fallback option.

Tested locally to make sure formatting and reference links work and go the correct places.
