### PR TITLE
Add details of non-matching mime type filter behaviour

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -2606,11 +2606,11 @@ when a 40x response would be returned.
         }
     }
 
-Here, all requests to images, fonts, and any text based files will have
+Here, all requests to images, fonts, and any text-based files will have
 a cache control header added to the response. Any other requests will still
 serve the files, but this time without the header. This is useful
 for serving common web page resources that do not change; web browsers
-and proxies are informed this content should be cached.
+and proxies are informed that this content should be cached.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty


### PR DESCRIPTION
Same as https://github.com/nginx/unit-docs/pull/66, but from my own fork instead of a different branch from the same unit-docs repository.

Closes #63 

* Adds details to main configuration documentation on what happens to mime type filtering when a request's mime type is not matched by any of the rules in the share option.
* Lifts example from the 1.24.0 news item for usage with a fallback option.

Tested locally to make sure formatting and reference links work and go the correct places.