### PR TITLE
GitHub is now our primary repository hosting environment

### DIFF
--- a/source/community.rst
+++ b/source/community.rst
@@ -24,10 +24,10 @@ Contribution
 
 NGINX Unit is released under the
 `Apache 2.0 license <https://hg.nginx.org/unit/file/tip/LICENSE>`_;
-we maintain Mercurial
-`repos <https://hg.nginx.org>`_,
-with mirrors on
-`GitHub <https://github.com/nginx>`_.
+we maintain GitHub
+`repos <https://github.com/nginx>`_,
+with Mercurial
+`mirrors <https://hg.nginx.org>`_.
 
 Please report any security-related issues
 concerning Unit to
@@ -48,15 +48,15 @@ or join our
 
 Source code:
 
-- Mercurial repository: https://hg.nginx.org/unit
-- GitHub mirror: https://github.com/nginx/unit
+- GitHub repository: https://github.com/nginx/unit
+- Mercurial mirror: https://hg.nginx.org/unit
 
 Command-line tools:
 
-- Mercurial repository: https://hg.nginx.org/unit/file/tip/tools
-- GitHub mirror: https://github.com/nginx/unit/tree/master/tools
+- GitHub repository: https://github.com/nginx/unit/tree/master/tools
+- Mercurial mirror: https://hg.nginx.org/unit/file/tip/tools
 
 Documentation:
 
-- Mercurial repository: https://hg.nginx.org/unit-docs
-- GitHub mirror: https://github.com/nginx/unit-docs
+- GitHub repository: https://github.com/nginx/unit-docs
+- Mercurial mirror: https://hg.nginx.org/unit-docs

--- a/source/community.rst
+++ b/source/community.rst
@@ -25,9 +25,7 @@ Contribution
 NGINX Unit is released under the
 `Apache 2.0 license <https://hg.nginx.org/unit/file/tip/LICENSE>`_;
 we maintain GitHub
-`repos <https://github.com/nginx>`_,
-with Mercurial
-`mirrors <https://hg.nginx.org>`_.
+`repos <https://github.com/nginx>`_.
 
 Please report any security-related issues
 concerning Unit to
@@ -49,14 +47,11 @@ or join our
 Source code:
 
 - GitHub repository: https://github.com/nginx/unit
-- Mercurial mirror: https://hg.nginx.org/unit
 
 Command-line tools:
 
 - GitHub repository: https://github.com/nginx/unit/tree/master/tools
-- Mercurial mirror: https://hg.nginx.org/unit/file/tip/tools
 
 Documentation:
 
 - GitHub repository: https://github.com/nginx/unit-docs
-- Mercurial mirror: https://hg.nginx.org/unit-docs

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -2693,8 +2693,7 @@ Source Code
 ***********
 
 You can get Unit's source code
-from our official GitHub repository,
-its Mercurial mirror,
+from our official GitHub repository
 or as a tarball.
 
 .. tabs::
@@ -2707,16 +2706,6 @@ or as a tarball.
          $ git clone https://github.com/nginx/unit            # Latest updates to the repository
          $ # -- or --
          $ git clone -b |version| https://github.com/nginx/unit  # Specific version tag; see https://github.com/nginx/unit/tags
-         $ cd unit
-
-
-   .. tab:: Mercurial
-
-      .. subs-code-block:: console
-
-         $ hg clone https://hg.nginx.org/unit             # Latest updates to the repository
-         $ # -- or --
-         $ hg clone https://hg.nginx.org/unit/ -u |version|  # Specific version tag; see https://hg.nginx.org/unit/tags
          $ cd unit
 
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -2693,23 +2693,12 @@ Source Code
 ***********
 
 You can get Unit's source code
-from our official Mercurial repository,
-its GitHub mirror,
+from our official GitHub repository,
+its Mercurial mirror,
 or as a tarball.
 
 .. tabs::
    :prefix: get-source
-
-   .. tab:: Mercurial
-
-      .. subs-code-block:: console
-
-         $ hg clone https://hg.nginx.org/unit             # Latest updates to the repository
-         $ # -- or --
-         $ hg clone https://hg.nginx.org/unit/ -u |version|  # Specific version tag; see https://hg.nginx.org/unit/tags
-         $ cd unit
-
-
 
    .. tab:: Git
 
@@ -2718,6 +2707,16 @@ or as a tarball.
          $ git clone https://github.com/nginx/unit            # Latest updates to the repository
          $ # -- or --
          $ git clone -b |version| https://github.com/nginx/unit  # Specific version tag; see https://github.com/nginx/unit/tags
+         $ cd unit
+
+
+   .. tab:: Mercurial
+
+      .. subs-code-block:: console
+
+         $ hg clone https://hg.nginx.org/unit             # Latest updates to the repository
+         $ # -- or --
+         $ hg clone https://hg.nginx.org/unit/ -u |version|  # Specific version tag; see https://hg.nginx.org/unit/tags
          $ cd unit
 
 


### PR DESCRIPTION
Now that we have switched to Git & GitHub as our primary VCS and repository hosting environment. This updates the community and installation pages to make GitHub the primary location for our repositories and our internally hosted Mercurial repositories to be the mirrors.

A second patch removes all mentions Mercurial.