### PR TITLE
Fix njs syntax in example

### DIFF
--- a/source/scripting.rst
+++ b/source/scripting.rst
@@ -184,7 +184,7 @@ with Unit-supplied header field values:
            "entry": [
                {
                    "action": {
-                       "pass": "routes/`${http.route(headers)}`"
+                       "pass": "`routes/${http.route(headers)}`"
                    }
                }
            ],


### PR DESCRIPTION
A '`' had got misplaced.