### PR TITLE
Add netlify.toml file for redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Used by Netlify for redirects. Lines with status code 200 are proxied and
+# rewritten by Netlify.
+
+# From the previous nginx.conf
+[[redirects]]
+  from = "/integration"
+  to = "/howto/integration"
+  status = 301
+
+# To keep old download links alive
+[[redirects]]
+  from = "/download/*"
+  to = "https://sources.nginx.org/unit/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}


### PR DESCRIPTION
This draft PR adds a [netlify.toml](https://docs.netlify.com/routing/redirects/redirect-options/) file for redirects. In its current state, it redirects downloads from https://unit.nginx.org/download/ to https://sources.nginx.org/unit/ which does not yet exist. 

~~Blocked by: #75~~ https://sources.nginx.org/unit/ is now live.