### PR TITLE
Update netlify.toml redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,14 @@
   to = "/howto/integration"
   status = 301
 
-# To keep old download links alive
+# The directory index is redirected to the new canonical location
+[[redirects]]
+  from = "/download"
+  to = "https://sources.nginx.org/unit/"
+  status = 301
+  headers = {X-From = "Netlify"}
+
+# To keep old download links alive, we proxy direct requests for specific files
 [[redirects]]
   from = "/download/*"
   to = "https://sources.nginx.org/unit/:splat"

--- a/source/howto/modules.rst
+++ b/source/howto/modules.rst
@@ -173,7 +173,7 @@ adjust the command samples as needed to fit your scenario.
 
          .. subs-code-block:: console
 
-            $ curl -O https://unit.nginx.org/download/unit-|version|.tar.gz
+            $ curl -O https://sources.nginx.org/unit/unit-|version|.tar.gz
             $ tar xzf unit-|version|.tar.gz                                 # Puts Unit's sources in the unit-|version| subdirectory
             $ cd unit-|version|
             $ ./configure :nxt_ph:`FLAGS W/O --LD-OPT & --NJS <The ./configure flags, except for --ld-opt and --njs>`                     # Use the ./configure flags noted in the previous step
@@ -283,7 +283,7 @@ adjust the command samples as needed to fit your scenario.
             Maintainer: Jane Doe <j.doe@example.com>
 
             %prep
-            curl -O https://unit.nginx.org/download/unit-|version|.tar.gz
+            curl -O https://sources.nginx.org/unit/unit-|version|.tar.gz
             # Downloads Unit's sources
             tar --strip-components=1 -xzf unit-|version|.tar.gz
             # Extracts them locally for compilation steps in the %build section

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -2714,7 +2714,7 @@ or as a tarball.
 
       .. subs-code-block:: console
 
-         $ curl -O https://unit.nginx.org/download/unit-|version|.tar.gz
+         $ curl -O https://sources.nginx.org/unit/unit-|version|.tar.gz
          $ tar xzf unit-|version|.tar.gz
          $ cd unit-|version|
 


### PR DESCRIPTION
The links on https://nginx-unit.netlify.app/download are relative and do not correctly correspond to the correct path. Instead of mangling the index to update the links to keep it on unit.nginx.org, we can just redirect the index separately from direct requests for the tarballs. The glob redirect still works for those links.

<img width="433" alt="Screenshot 2024-02-01 at 11 55 21 AM" src="https://github.com/nginx/unit-docs/assets/667598/81106a08-214a-4cca-95c4-ead5c45fe54f">

These relative links are missing /download in the path, because of the move to sources.nginx.org. 
