### PR TITLE
feat: change inline to bold

### DIFF
--- a/source/certificates.rst
+++ b/source/certificates.rst
@@ -7,16 +7,16 @@
 .. _configuration-ssl:
 
 ####################
-SSL/TLS Certificates
+SSL/TLS certificates
 ####################
 
-The :samp:`/certificates` section of the
+The **/certificates** section of the
 :ref:`control API <configuration-api>`
 handles TLS certificates that are used with Unit's
 :ref:`listeners <configuration-listeners>`.
 
 To set up SSL/TLS for a listener,
-upload a :file:`.pem` file with your certificate chain and private key to Unit
+upload a **.pem** file with your certificate chain and private key to Unit,
 and name the uploaded bundle in the listener's configuration;
 next, the listener can be accessed via SSL/TLS.
 
@@ -25,7 +25,7 @@ next, the listener can be accessed via SSL/TLS.
    For the details of certificate issuance and renewal in Unit,
    see an example in :doc:`howto/certbot`.
 
-First, create a :file:`.pem` file with your certificate chain and private key:
+First, create a **.pem** file with your certificate chain and private key:
 
 .. code-block:: console
 
@@ -39,7 +39,7 @@ order them leaf to root.
 
 Upload the resulting bundle file to Unit's certificate storage
 under a suitable name
-(in this case, :samp:`bundle`):
+(in this case, **bundle**):
 
 .. code-block:: console
 
@@ -52,19 +52,19 @@ under a suitable name
 
 .. warning::
 
-   Don't use :option:`!-d` for file upload with :program:`curl`;
-   this option damages :file:`.pem` files.
-   Use the :option:`!--data-binary` option
+   Don't use **-d** for file upload with :program:`curl`;
+   this option damages **.pem** files.
+   Use the **--data-binary** option
    when uploading file-based data
    to avoid data corruption.
 
 Internally, Unit stores the uploaded certificate bundles
 along with other configuration data
-in its :file:`state` subdirectory;
+in its **state** subdirectory;
 the
 :ref:`control API <configuration-api>`
 exposes some of their properties
-as :samp:`GET`-table JSON via :samp:`/certificates`:
+as **GET**-table JSON using **/certificates**:
 
 .. code-block:: json
 
@@ -191,7 +191,7 @@ the application is now accessible via SSL/TLS:
        * SSL connection using TLSv1.2 / AES256-GCM-SHA384
        ...
 
-Finally, you can :samp:`DELETE` a certificate bundle
+Finally, you can delete a certificate bundle
 that you don't need anymore
 from the storage:
 
@@ -207,5 +207,4 @@ from the storage:
 .. note::
 
    You can't delete certificate bundles still referenced in your
-   configuration, overwrite existing bundles using :samp:`PUT`, or (obviously)
-   delete non-existent ones.
+   configuration, overwrite existing bundles using **put**, or delete non-existent ones.

--- a/source/community.rst
+++ b/source/community.rst
@@ -9,7 +9,7 @@ Community
 #########
 
 We hold semi-regular meetings on Zoom
-to discuss all things pertaining to Unit
+to discuss all things related to Unit
 with our tightly knit and vibrant community.
 
 Recorded sessions:

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -8,7 +8,7 @@
 Configuration
 #############
 
-The :samp:`/config` section of the
+The **/config** section of the
 :ref:`control API <configuration-api>`
 handles Unit's general configuration with entities such as
 :ref:`listeners <configuration-listeners>`,
@@ -24,19 +24,19 @@ Listeners
 *********
 
 To accept requests,
-add a listener object in the :samp:`config/listeners` API section;
+add a listener object in the **config/listeners** API section;
 the object's name can be:
 
 - A unique IP socket:
-  :samp:`127.0.0.1:80`, :samp:`[::1]:8080`
+  **127.0.0.1:80**, **[::1]:8080**
 
 - A wildcard that matches any host IPs on the port:
-  :samp:`*:80`
+  ***:80**
 
 - On Linux-based systems,
   `abstract UNIX sockets <https://man7.org/linux/man-pages/man7/unix.7.html>`__
   can be used as well:
-  :samp:`unix:@abstract_socket`.
+  **unix:@abstract_socket**.
 
 .. note::
 
@@ -44,10 +44,10 @@ the object's name can be:
    wildcard listeners can't overlap with other listeners
    on the same port
    due to rules imposed by the kernel.
-   For example, :samp:`*:8080` conflicts with :samp:`127.0.0.1:8080`;
+   For example, ***:8080** conflicts with **127.0.0.1:8080**;
    in particular,
-   this means :samp:`*:8080` can't be *immediately* replaced
-   by :samp:`127.0.0.1:8080`
+   this means ***:8080** can't be *immediately* replaced
+   by **127.0.0.1:8080**
    (or vice versa)
    without deleting it first.
 
@@ -65,23 +65,23 @@ Available listener options:
     * - Option
       - Description
 
-    * - :samp:`pass` (required)
+    * - **pass** (required)
       - Destination to which the listener passes incoming requests.
         Possible alternatives:
 
         - :ref:`Application <configuration-applications>`:
-          :samp:`applications/qwk2mart`
+          **applications/qwk2mart**
 
         - :ref:`PHP target <configuration-php-targets>`
           or
           :ref:`Python target <configuration-python-targets>`:
-          :samp:`applications/myapp/section`
+          **applications/myapp/section**
 
         - :ref:`Route <configuration-routes>`:
-          :samp:`routes/route66`, :samp:`routes`
+          **routes/route66**, **routes**
 
         - :ref:`Upstream <configuration-upstreams>`:
-          :samp:`upstreams/rr-lb`
+          **upstreams/rr-lb**
 
         The value is
         :ref:`variable <configuration-variables>`
@@ -89,25 +89,25 @@ Available listener options:
         if it matches no configuration entities after interpolation,
         a 404 "Not Found" response is returned.
 
-    * - :samp:`forwarded`
+    * - **forwarded**
       - Object;
         configures client IP address and protocol
         :ref:`replacement <configuration-listeners-forwarded>`.
 
-    * - :samp:`tls`
+    * - **tls**
       - Object;
         defines SSL/TLS
         :ref:`settings <configuration-listeners-ssl>`.
 
 
 Here, a local listener accepts requests at port 8300
-and passes them to the :samp:`blogs` app
+and passes them to the **blogs** app
 :ref:`target <configuration-php-targets>`
-identified by the :samp:`uri`
+identified by the **uri**
 :ref:`variable <configuration-variables>`.
 The wildcard listener on port 8400
 relays requests at any host IPs
-to the :samp:`main`
+to the **main**
 :ref:`route
 <configuration-routes>`:
 
@@ -123,7 +123,7 @@ to the :samp:`main`
         }
     }
 
-Also, :samp:`pass` values can be
+Also, **pass** values can be
 `percent encoded
 <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__.
 For example, you can escape slashes in entity names:
@@ -145,10 +145,10 @@ For example, you can escape slashes in entity names:
 .. _configuration-listeners-ssl:
 
 =====================
-SSL/TLS Configuration
+SSL/TLS configuration
 =====================
 
-The :samp:`tls` object provides the following options:
+The **tls** object provides the following options:
 
 .. list-table::
    :header-rows: 1
@@ -156,14 +156,14 @@ The :samp:`tls` object provides the following options:
    * - Option
      - Description
 
-   * - :samp:`certificate` (required)
+   * - **certificate** (required)
      - String or an array of strings;
        refers to one or more
        :ref:`certificate bundles <configuration-ssl>`
        uploaded earlier,
        enabling secure communication via the listener.
 
-   * - :samp:`conf_commands`
+   * - **conf_commands**
      - Object;
        defines the OpenSSL
        `configuration commands
@@ -182,14 +182,14 @@ The :samp:`tls` object provides the following options:
        Also, make sure your OpenSSL version supports the commands
        set by this option.
 
-   * - :samp:`session`
+   * - **session**
      - Object; configures the TLS session cache and tickets
        for the listener.
 
 To use a certificate bundle you
 :ref:`uploaded <configuration-ssl>`
 earlier,
-name it in the :samp:`certificate` option of the :samp:`tls` object:
+name it in the **certificate** option of the **tls** object:
 
 .. code-block:: json
 
@@ -204,7 +204,7 @@ name it in the :samp:`certificate` option of the :samp:`tls` object:
        }
    }
 
-.. nxt_details:: Configuring Multiple Bundles
+.. nxt_details:: Configuring multiple bundles
    :hash: conf-bundles
 
    Since version 1.23.0,
@@ -213,7 +213,7 @@ name it in the :samp:`certificate` option of the :samp:`tls` object:
    <https://datatracker.ietf.org/doc/html/rfc6066#section-3>`__
    on a listener
    by supplying an array of certificate bundle names
-   for the :samp:`certificate` option value:
+   for the **certificate** option value:
 
    .. code-block:: json
 
@@ -242,7 +242,7 @@ To set custom OpenSSL
 `configuration commands
 <https://www.openssl.org/docs/manmaster/man3/SSL_CONF_cmd.html>`__
 for a listener,
-use the :samp:`conf_commands` object in :samp:`tls`:
+use the **conf_commands** object in **tls**:
 
 .. code-block:: json
 
@@ -258,7 +258,7 @@ use the :samp:`conf_commands` object in :samp:`tls`:
 
 .. _configuration-listeners-ssl-sessions:
 
-The :samp:`session` object in :samp:`tls`
+The **session** object in **tls**
 configures the session settings of the listener:
 
 .. list-table::
@@ -267,30 +267,30 @@ configures the session settings of the listener:
    * - Option
      - Description
 
-   * - :samp:`cache_size`
+   * - **cache_size**
      - Integer;
        sets the number of sessions in the TLS session cache.
 
-       The default is :samp:`0`
+       The default is **0**
        (caching is disabled).
 
-   * - :samp:`tickets`
+   * - **tickets**
      - Boolean, string, or an array of strings;
        configures TLS session tickets.
 
-       The default is :samp:`false`
+       The default is **false**
        (tickets are disabled).
 
-   * - :samp:`timeout`
+   * - **timeout**
      - Integer;
        sets the session timeout for the TLS session cache.
 
        When a new session is created,
-       its lifetime derives from current time and :samp:`timeout`.
+       its lifetime derives from current time and **timeout**.
        If a cached session is requested past its lifetime,
        it is not reused.
 
-       The default is :samp:`300`
+       The default is **300**
        (5 minutes).
 
 Example:
@@ -312,10 +312,10 @@ Example:
        }
    }
 
-The :samp:`tickets` option works as follows:
+The **tickets** option works as follows:
 
 - Boolean values enable or disable session tickets;
-  with :samp:`true`, a random session ticket key is used:
+  with **true**, a random session ticket key is used:
 
   .. code-block:: json
 
@@ -339,7 +339,7 @@ The :samp:`tickets` option works as follows:
   This enables ticket reuse in scenarios
   where the key is shared between individual servers.
 
-  .. nxt_details:: Shared Key Rotation
+  .. nxt_details:: Shared key rotation
      :hash: key-rotation
 
      If multiple Unit instances need to recognize tickets
@@ -348,8 +348,8 @@ The :samp:`tickets` option works as follows:
      they should share session ticket keys.
 
      For example,
-     consider three SSH-enabled servers named :samp:`unit*.example.com`,
-     with Unit installed and identical :samp:`*:443` listeners configured.
+     consider three SSH-enabled servers named **unit*.example.com**,
+     with Unit installed and identical ***:443** listeners configured.
      To configure a single set of three initial keys on each server:
 
      .. code-block:: shell
@@ -428,16 +428,16 @@ The :samp:`tickets` option works as follows:
   .. note::
 
      An empty array effectively disables session tickets,
-     same as setting :samp:`tickets` to :samp:`false`.
+     same as setting **tickets** to **false**.
 
 .. _configuration-listeners-forwarded:
 
 =======================
-IP, Protocol Forwarding
+IP, protocol forwarding
 =======================
 
-Unit enables the :samp:`X-Forwarded-*` header fields
-with the :samp:`forwarded` object and its options:
+Unit enables the **X-Forwarded-*** header fields
+with the **forwarded** object and its options:
 
 .. list-table::
     :header-rows: 1
@@ -445,7 +445,7 @@ with the :samp:`forwarded` object and its options:
     * - Option
       - Description
 
-    * - :samp:`source` (required)
+    * - **source** (required)
       - String or an array of strings;
         defines
         :ref:`address-based patterns
@@ -454,10 +454,10 @@ with the :samp:`forwarded` object and its options:
         Replacement occurs only if the source IP of the request is a
         :ref:`match <configuration-routes-matching-resolution>`.
 
-        A special case here is the :samp:`"unix"` string;
+        A special case here is the **"unix"** string;
         it matches *any* UNIX domain sockets.
 
-    * - :samp:`client_ip`
+    * - **client_ip**
       - String;
         names the HTTP header fields to expect in the request.
         They should use the
@@ -466,7 +466,7 @@ with the :samp:`forwarded` object and its options:
         format where the value is a comma- or space-separated list
         of IPv4s or IPv6s.
 
-    * - :samp:`protocol`
+    * - **protocol**
       - String;
         defines the relevant HTTP header field to look for in the request.
         Unit expects it to follow the
@@ -474,54 +474,54 @@ with the :samp:`forwarded` object and its options:
         <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto>`__
         notation,
         with the field value itself
-        being :samp:`http`, :samp:`https`, or :samp:`on`.
+        being **http**, **https**, or **on**.
 
-    * - :samp:`recursive`
+    * - **recursive**
       - Boolean;
-        controls how the :samp:`client_ip` fields are traversed.
+        controls how the **client_ip** fields are traversed.
 
-        The default is :samp:`false`
+        The default is **false**
         (no recursion).
 
 .. note::
 
-   Besides :samp:`source`,
-   the :samp:`forwarded` object must specify
-   :samp:`client_ip`, :samp:`protocol`, or both.
+   Besides **source**,
+   the **forwarded** object must specify
+   **client_ip**, **protocol**, or both.
 
 .. warning::
 
    Before version 1.28.0,
-   Unit provided the :samp:`client_ip` object
-   that evolved into :samp:`forwarded`:
+   Unit provided the **client_ip** object
+   that evolved into **forwarded**:
 
    .. list-table::
        :header-rows: 1
 
-       * - :samp:`client_ip` (pre-1.28.0)
-         - :samp:`forwarded` (post-1.28.0)
+       * - **client_ip** (pre-1.28.0)
+         - **forwarded** (post-1.28.0)
 
-       * - :samp:`header`
-         - :samp:`client_ip`
+       * - **header**
+         - **client_ip**
 
-       * - :samp:`recursive`
-         - :samp:`recursive`
+       * - **recursive**
+         - **recursive**
 
-       * - :samp:`source`
-         - :samp:`source`
+       * - **source**
+         - **source**
 
        * - N/A
-         - :samp:`protocol`
+         - **protocol**
 
    This old syntax still works but will be eventually deprecated,
    though not earlier than version 1.30.0.
 
 
-When :samp:`forwarded` is set,
+When **forwarded** is set,
 Unit respects the appropriate header fields
 only if the immediate source IP of the request
 :ref:`matches <configuration-routes-matching-resolution>`
-the :samp:`source` option.
+the **source** option.
 Mind that it can use not only subnets but any
 :ref:`address-based patterns <configuration-routes-matching-patterns>`:
 
@@ -540,13 +540,13 @@ Mind that it can use not only subnets but any
 
 .. _configuration-listeners-xfp:
 
-Overwriting Protocol Scheme
+Overwriting protocol scheme
 ***************************
 
-The :samp:`protocol` option enables overwriting
+The **protocol** option enables overwriting
 the incoming request's protocol scheme
 based on the header field it specifies.
-Consider the following :samp:`forwarded` configuration:
+Consider the following **forwarded** configuration:
 
 .. code-block:: json
 
@@ -566,16 +566,16 @@ Suppose a request arrives with the following header field:
 
    X-Forwarded-Proto: https
 
-If the source IP of the request matches :samp:`source`,
-Unit handles this request as an :samp:`https` one.
+If the source IP of the request matches **source**,
+Unit handles this request as an **https** one.
 
 .. _configuration-listeners-xff:
 
-Originating IP Identification
+Originating IP identification
 *****************************
 
 Unit also supports identifying the clients' originating IPs
-with the :samp:`client_ip` option:
+with the **client_ip** option:
 
 .. code-block:: json
 
@@ -597,20 +597,20 @@ Suppose a request arrives with the following header fields:
    X-Forwarded-For: 192.0.2.18
    X-Forwarded-For: 203.0.113.195, 198.51.100.178
 
-If :samp:`recursive` is set to :samp:`false`
+If **recursive** is set to **false**
 (default),
 Unit chooses the *rightmost* address of the *last* field
-named in :samp:`client_ip`
+named in **client_ip**
 as the originating IP of the request.
 In the example,
 it's set to 198.51.100.178 for requests from 192.0.2.0/24 or 198.51.100.0/24.
 
-If :samp:`recursive` is set to :samp:`true`,
-Unit inspects all :samp:`client_ip` fields in reverse order.
+If **recursive** is set to **true**,
+Unit inspects all **client_ip** fields in reverse order.
 Each is traversed from right to left
 until the first non-trusted address;
 if found, it's chosen as the originating IP.
-In the previous example with :samp:`"recursive": true`,
+In the previous example with **"recursive": true**,
 the client IP would be set to 203.0.113.195
 because 198.51.100.178 is also trusted;
 this simplifies working behind multiple reverse proxies.
@@ -622,7 +622,7 @@ this simplifies working behind multiple reverse proxies.
 Routes
 ******
 
-The :samp:`config/routes` configuration entity
+The **config/routes** configuration entity
 defines internal request routing.
 It receives requests
 from :ref:`listeners <configuration-listeners>`
@@ -641,7 +641,7 @@ with arbitrary status codes, or
 :ref:`redirected <configuration-return>`.
 
 In its simplest form,
-:samp:`routes` is an array
+**routes** is an array
 that defines a single route:
 
 .. code-block:: json
@@ -685,7 +685,7 @@ with one or more named route arrays as members:
 .. _configuration-routes-step:
 
 ===========
-Route Steps
+Route steps
 ===========
 
 A
@@ -699,12 +699,12 @@ they accept the following options:
    * - Option
      - Description
 
-   * - :samp:`action` (required)
+   * - **action** (required)
      - Object;
        defines how matching requests are
        :ref:`handled <configuration-routes-action>`.
 
-   * - :samp:`match`
+   * - **match**
      - Object;
        defines the step's
        :ref:`conditions <configuration-routes-matching>`
@@ -712,9 +712,9 @@ they accept the following options:
 
 A request passed to a route traverses its steps sequentially:
 
-- If all :samp:`match` conditions in a step are met,
+- If all **match** conditions in a step are met,
   the traversal ends
-  and the step's :samp:`action` is performed.
+  and the step's **action** is performed.
 
 - If a step's condition isn't met,
   Unit proceeds to the next step of the route.
@@ -724,12 +724,12 @@ A request passed to a route traverses its steps sequentially:
 
 .. warning::
 
-  If a step omits the :samp:`match` option,
-  its :samp:`action` occurs automatically.
+  If a step omits the **match** option,
+  its **action** occurs automatically.
   Thus, use no more than one such step per route,
   always placing it last to avoid potential routing issues.
 
-.. nxt_details:: Ad-Hoc Examples
+.. nxt_details:: Ad-Hoc examples
    :hash: conf-route-examples
 
    A basic one:
@@ -758,10 +758,10 @@ A request passed to a route traverses its steps sequentially:
       }
 
    This route passes all HTTPS requests
-   to the :samp:`/php/` subsection of the :samp:`example.com` website
-   to the :samp:`php_version` app.
+   to the **/php/** subsection of the **example.com** website
+   to the **php_version** app.
    All other requests are served with static content
-   from the :samp:`/www/static_version/` directory.
+   from the **/www/static_version/** directory.
    If there's no matching content,
    a 404 "Not Found" response is returned.
 
@@ -824,15 +824,15 @@ A request passed to a route traverses its steps sequentially:
           }
       }
 
-   Here, a route called :samp:`main` is explicitly defined,
-   so :samp:`routes` is an object instead of an array.
+   Here, a route called **main** is explicitly defined,
+   so **routes** is an object instead of an array.
    The first step of the route passes all HTTP requests
-   to the :samp:`http_site` app.
+   to the **http_site** app.
    The second step passes all requests
-   that target :samp:`blog.example.com`
-   to the :samp:`blog` app.
+   that target **blog.example.com**
+   to the **blog** app.
    The final step serves requests for certain file types
-   from the :samp:`/www/static/` directory.
+   from the **/www/static/** directory.
    If no steps match,
    a 404 "Not Found" response is returned.
 
@@ -840,12 +840,12 @@ A request passed to a route traverses its steps sequentially:
 .. _configuration-routes-matching:
 
 ===================
-Matching Conditions
+Matching conditions
 ===================
 
 Conditions in a
 :ref:`route step <configuration-routes-step>`'s
-:samp:`match` object
+**match** object
 define patterns to be compared to the request's properties:
 
 .. list-table::
@@ -857,7 +857,7 @@ define patterns to be compared to the request's properties:
        relates to property names and values; for other properties, case
        sensitivity affects only values>`
 
-   * - :samp:`arguments`
+   * - **arguments**
      - Arguments supplied with the request's
        `query string
        <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__;
@@ -865,26 +865,26 @@ define patterns to be compared to the request's properties:
        `percent decoded
        <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__,
        with plus signs
-       (:samp:`+`)
+       (**+**)
        replaced by spaces.
      - Yes
 
-   * - :samp:`cookies`
+   * - **cookies**
      - Cookies supplied with the request.
      - Yes
 
-   * - :samp:`destination`
+   * - **destination**
      - Target IP address and optional port of the request.
      - No
 
-   * - :samp:`headers`
+   * - **headers**
      - `Header fields
        <https://datatracker.ietf.org/doc/html/rfc9110#section-6-3>`__
        supplied with the request.
      - No
 
-   * - :samp:`host`
-     - :samp:`Host`
+   * - **host**
+     - **Host**
        `header field
        <https://datatracker.ietf.org/doc/html/rfc9110#section-7-2>`__,
        converted to lower case and normalized
@@ -892,35 +892,35 @@ define patterns to be compared to the request's properties:
        (if any).
      - No
 
-   * - :samp:`method`
+   * - **method**
      - `Method <https://datatracker.ietf.org/doc/html/rfc7231#section-4>`__
        from the request line,
        uppercased.
      - No
 
-   * - :samp:`query`
+   * - **query**
      - `Query string
        <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__,
        `percent decoded
        <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__,
        with plus signs
-       (:samp:`+`)
+       (**+**)
        replaced by spaces.
      - Yes
 
-   * - :samp:`scheme`
+   * - **scheme**
      - URI
        `scheme
        <https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml>`__.
        Accepts only two patterns,
-       either :samp:`http` or :samp:`https`.
+       either **http** or **https**.
      - No
 
-   * - :samp:`source`
+   * - **source**
      - Source IP address and optional port of the request.
      - No
 
-   * - :samp:`uri`
+   * - **uri**
      - `Request target
        <https://datatracker.ietf.org/doc/html/rfc9110#target.resource>`__,
        `percent decoded
@@ -935,15 +935,15 @@ define patterns to be compared to the request's properties:
        ("." and "..", "//").
      - Yes
 
-.. nxt_details:: Arguments vs. Query
+.. nxt_details:: Arguments vs. query
    :hash: args-vs-query
 
-   Both :samp:`arguments` and :samp:`query` operate on the query string,
-   but :samp:`query` is matched against the entire string
-   whereas :samp:`arguments` considers only the key-value pairs
-   such as :samp:`key1=4861&key2=a4f3`.
+   Both **arguments** and **query** operate on the query string,
+   but **query** is matched against the entire string
+   whereas **arguments** considers only the key-value pairs
+   such as **key1=4861&key2=a4f3**.
 
-   Use :samp:`arguments` to define conditions
+   Use **arguments** to define conditions
    based on key-value pairs in the query string:
 
    .. code-block:: json
@@ -954,10 +954,10 @@ define patterns to be compared to the request's properties:
       }
 
    Argument order is irrelevant:
-   :samp:`key1=4861&key2=a4f3` and :samp:`key2=a4f3&key1=4861`
+   **key1=4861&key2=a4f3** and **key2=a4f3&key1=4861**
    are considered the same.
    Also, multiple occurrences of an argument must all match,
-   so :samp:`key=4861&key=a4f3` matches this:
+   so **key=4861&key=a4f3** matches this:
 
    .. code-block:: json
 
@@ -974,7 +974,7 @@ define patterns to be compared to the request's properties:
       }
 
    To the contrary,
-   use :samp:`query`
+   use **query**
    if your conditions concern query strings
    but don't rely on key-value pairs:
 
@@ -987,24 +987,24 @@ define patterns to be compared to the request's properties:
 
    This only matches query strings
    of the form
-   :samp:`https://example.com?utf8` or :samp:`https://example.com?utf16`.
+   **https://example.com?utf8** or **https://example.com?utf16**.
 
 
 .. _configuration-routes-matching-resolution:
 
-Match Resolution
+Match resolution
 ****************
 
 To be a match,
 the property must meet two requirements:
 
 - If there are patterns without negation
-  (the :samp:`!` prefix),
+  (the **!** prefix),
   at least one of them matches the property value.
 
 - No negated patterns match the property value.
 
-.. nxt_details:: Formal Explanation
+.. nxt_details:: Formal explanation
    :hash: pattern-set-theory
 
    This logic can be described with set operations.
@@ -1017,8 +1017,8 @@ the property must meet two requirements:
    | *U* ∩ *P* \\ *N* if *P* ≠ ∅
    | *U* \\ *N* if *P* = ∅
 
-Here, the URI of the request must fit :samp:`pattern3`,
-but must not match :samp:`pattern1` or :samp:`pattern2`:
+Here, the URI of the request must fit **pattern3**,
+but must not match **pattern1** or **pattern2**:
 
 .. code-block:: json
 
@@ -1037,7 +1037,7 @@ but must not match :samp:`pattern1` or :samp:`pattern2`:
    }
 
 Additionally, special matching logic applies to
-:samp:`arguments`, :samp:`cookies`, and :samp:`headers`.
+**arguments**, **cookies**, and **headers**.
 Each of these can be either
 a single object that lists custom-named properties and their patterns
 or an array of such objects.
@@ -1047,7 +1047,7 @@ the request must match *all* properties named in the object.
 To match an object array,
 it's enough to match *any* single one of its item objects.
 The following condition matches only
-if the request arguments include :samp:`arg1` and :samp:`arg2`,
+if the request arguments include **arg1** and **arg2**,
 and both match their patterns:
 
 .. code-block:: json
@@ -1068,7 +1068,7 @@ and both match their patterns:
 With an object array,
 the condition matches
 if the request's arguments include
-:samp:`arg1` or :samp:`arg2`
+**arg1** or **arg2**
 (or both)
 that matches the respective pattern:
 
@@ -1092,14 +1092,14 @@ that matches the respective pattern:
    }
 
 The following example combines all matching types.
-Here, :samp:`host`, :samp:`method`, :samp:`uri`,
-:samp:`arg1` *and* :samp:`arg2`,
-either :samp:`cookie1` or :samp:`cookie2`,
-and either :samp:`header1` or :samp:`header2` *and* :samp:`header3`
+Here, **host**, **method**, **uri**,
+**arg1** *and* **arg2**,
+either **cookie1** or **cookie2**,
+and either **header1** or **header2** *and* **header3**
 must be matched
-for the :samp:`action` to be taken
-(:samp:`host & method & uri & arg1 & arg2 & (cookie1 | cookie2)
-& (header1 | (header2 & header3))`):
+for the **action** to be taken
+(**host & method & uri & arg1 & arg2 & (cookie1 | cookie2)
+& (header1 | (header2 & header3))**):
 
 .. code-block:: json
 
@@ -1142,11 +1142,11 @@ for the :samp:`action` to be taken
        }
    }
 
-.. nxt_details:: Object Pattern Examples
+.. nxt_details:: Object pattern examples
    :hash: conf-obj-pattern-examples
 
-   This requires :samp:`mode=strict`
-   and any :samp:`access` argument other than :samp:`access=full`
+   This requires **mode=strict**
+   and any **access** argument other than **access=full**
    in the URI query:
 
    .. code-block:: json
@@ -1165,8 +1165,8 @@ for the :samp:`action` to be taken
       }
 
    This matches requests that
-   either use :samp:`gzip` and identify as :samp:`Mozilla/5.0`
-   or list :samp:`curl` as the user agent:
+   either use **gzip** and identify as **Mozilla/5.0**
+   or list **curl** as the user agent:
 
    .. code-block:: json
 
@@ -1191,12 +1191,12 @@ for the :samp:`action` to be taken
 
 .. _configuration-routes-matching-patterns:
 
-Pattern Syntax
+Pattern syntax
 **************
 
 Individual patterns can be
 address-based
-(:samp:`source` and :samp:`destination`)
+(**source** and **destination**)
 or string-based
 (other properties).
 
@@ -1207,33 +1207,33 @@ which is the default for the official packages>`
 modify this behavior:
 
 - A wildcard pattern may contain any combination of wildcards
-  (:samp:`*`),
+  (*****),
   each standing for an arbitrary number of characters:
-  :samp:`How*s*that*to*you`.
+  **How*s*that*to*you**.
 
 .. _configuration-routes-matching-patterns-regex:
 
 - A regex pattern starts with a tilde
-  (:samp:`~`):
-  :samp:`~^\\\\d+\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+`
+  (**~**):
+  **~^\\d+\\.\\d+\\.\\d+\\.\\d+**
   (escaping backslashes is a
   `JSON requirement <https://www.json.org/json-en.html>`_).
   The regexes are
   `PCRE <https://www.pcre.org/current/doc/html/pcre2syntax.html>`_-flavored.
 
-.. nxt_details:: Percent Encoding In Arguments, Query, and URI Patterns
+.. nxt_details:: Percent encoding in arguments, query, and URI patterns
    :hash: percent-encoding
 
-   Argument names, non-regex string patterns in :samp:`arguments`,
-   :samp:`query`, and :samp:`uri` can be
+   Argument names, non-regex string patterns in **arguments**,
+   **query**, and **uri** can be
    `percent encoded
    <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__
    to mask special characters
-   (:samp:`!` is :samp:`%21`, :samp:`~` is :samp:`%7E`,
-   :samp:`*` is :samp:`%2A`, :samp:`%` is :samp:`%25`)
+   (**!** is **%21**, **~** is **%7E**,
+   ***** is **%2A**, **%** is **%25**)
    or even target single bytes.
    For example, you can select diacritics such as Ö or Å
-   by their starting byte :samp:`0xC3` in UTF-8:
+   by their starting byte **0xC3** in UTF-8:
 
    .. code-block:: json
 
@@ -1281,19 +1281,19 @@ modify this behavior:
             ...
 
    Note that the encoded spaces
-   (:samp:`%20`)
+   (**%20**)
    in the request
    match their unencoded counterparts in the pattern;
    vice versa, the encoded tilde
-   (:samp:`%7E`)
-   in the condition matches :samp:`~` in the request.
+   (**%7E**)
+   in the condition matches **~** in the request.
 
 
-.. nxt_details:: String Pattern Examples
+.. nxt_details:: String pattern examples
    :hash: conf-str-pattern-examples
 
-   A regular expression that matches any :file:`.php` files
-   in the :file:`/data/www/` directory and its subdirectories.
+   A regular expression that matches any **.php** files
+   in the **/data/www/** directory and its subdirectories.
    Note the backslashes;
    escaping is a JSON-specific requirement:
 
@@ -1309,7 +1309,7 @@ modify this behavior:
           }
       }
 
-   Only subdomains of :samp:`example.com` match:
+   Only subdomains of **example.com** match:
 
    .. code-block:: json
 
@@ -1323,8 +1323,8 @@ modify this behavior:
           }
       }
 
-   Only requests for :samp:`.php` files
-   located in :file:`/admin/`'s subdirectories
+   Only requests for **.php** files
+   located in **/admin/**'s subdirectories
    match:
 
    .. code-block:: json
@@ -1339,8 +1339,8 @@ modify this behavior:
           }
       }
 
-   Here, any :samp:`eu-` subdomains of :samp:`example.com` match
-   except :samp:`eu-5.example.com`:
+   Here, any **eu-** subdomains of **example.com** match
+   except **eu-5.example.com**:
 
    .. code-block:: json
 
@@ -1358,7 +1358,7 @@ modify this behavior:
       }
 
    Any methods match
-   except :samp:`HEAD` and :samp:`GET`:
+   except **HEAD** and **GET**:
 
    .. code-block:: json
 
@@ -1377,7 +1377,7 @@ modify this behavior:
 
    You can also combine certain special characters in a pattern.
    Here, any URIs match
-   except the ones containing :samp:`/api/`:
+   except the ones containing **/api/**:
 
    .. code-block:: json
 
@@ -1392,7 +1392,7 @@ modify this behavior:
       }
 
    Here, URIs of any articles
-   that don't look like :samp:`YYYY-MM-DD` dates
+   that don't look like **YYYY-MM-DD** dates
    match.
    Again, note the backslashes;
    they are a JSON requirement:
@@ -1426,18 +1426,18 @@ that must exactly match the property;
 wildcards and ranges modify this behavior:
 
 - Wildcards
-  (:samp:`*`)
+  (*****)
   can only match arbitrary IPs
-  (:samp:`*:<port>`).
+  (***:<port>**).
 
 - Ranges
-  (:samp:`-`)
+  (**-**)
   work with both IPs
   (in respective notation)
   and ports
-  (:samp:`<start_port>-<end_port>`).
+  (**<start_port>-<end_port>**).
 
-.. nxt_details:: Address-Based Allow-Deny Lists
+.. nxt_details:: Address-based allow-deny lists
    :hash: allow-deny
 
    Addresses come in handy
@@ -1481,7 +1481,7 @@ wildcards and ranges modify this behavior:
           root /www/data;
       }
 
-.. nxt_details::  Address Pattern Examples
+.. nxt_details::  Address pattern examples
    :hash: conf-addr-pattern-examples
 
    This uses IPv4-based matching with wildcards and ranges:
@@ -1556,7 +1556,7 @@ wildcards and ranges modify this behavior:
       }
 
    Here, any IPs from the range match
-   except :samp:`192.0.2.9`:
+   except **192.0.2.9**:
 
    .. code-block:: json
 
@@ -1610,15 +1610,15 @@ wildcards and ranges modify this behavior:
 .. _configuration-routes-action:
 
 ================
-Handling Actions
+Handling actions
 ================
 
 If a request matches all
 :ref:`conditions <configuration-routes-matching>`
 of a route step
-or the step itself omits the :samp:`match` object,
-Unit handles the request with the respective :samp:`action`.
-The mutually exclusive :samp:`action` types are:
+or the step itself omits the **match** object,
+Unit handles the request with the respective **action**.
+The mutually exclusive **action** types are:
 
 .. list-table::
    :header-rows: 1
@@ -1627,22 +1627,22 @@ The mutually exclusive :samp:`action` types are:
      - Description
      - Details
 
-   * - :samp:`pass`
+   * - **pass**
      - Destination for the request,
-       identical to a listener's :samp:`pass` option.
+       identical to a listener's **pass** option.
      - :ref:`configuration-listeners`
 
-   * - :samp:`proxy`
+   * - **proxy**
      - Socket address of an HTTP server
        to where the request is proxied.
      - :ref:`configuration-proxy`
 
-   * - :samp:`return`
+   * - **return**
      - HTTP status code
        with a context-dependent redirect location.
      - :ref:`configuration-return`
 
-   * - :samp:`share`
+   * - **share**
      - File paths that serve the request with static content.
      - :ref:`configuration-static`
 
@@ -1655,12 +1655,12 @@ An additional option is applicable to any of these actions:
      - Description
      - Details
 
-   * - :samp:`response_headers`
+   * - **response_headers**
      - Updates the header fields
        of the upcoming response.
      - :ref:`configuration-response-headers`
 
-   * - :samp:`rewrite`
+   * - **rewrite**
      - Updated the request URI,
        preserving the query string.
      - :ref:`configuration-rewrite`
@@ -1742,58 +1742,58 @@ There's a number of built-in variables available:
    * - Variable
      - Description
 
-   * - :samp:`arg_*`, :samp:`cookie_*`, :samp:`header_*`
+   * - **arg_***, **cookie_***, **header_***
      - Variables that store
        :ref:`request arguments, cookies, and header fields
        <configuration-routes-matching>`,
-       such as :samp:`arg_queryTimeout`,
-       :samp:`cookie_sessionId`,
-       or :samp:`header_Accept_Encoding`.
-       The names of the :samp:`header_*` variables are case insensitive.
+       such as **arg_queryTimeout**,
+       **cookie_sessionId**,
+       or **header_Accept_Encoding**.
+       The names of the **header_*** variables are case insensitive.
 
-   * - :samp:`body_bytes_sent`
+   * - **body_bytes_sent**
      - Number of bytes sent in the response body.
 
-   * - :samp:`dollar`
-     - Literal dollar sign (:samp:`$`),
+   * - **dollar**
+     - Literal dollar sign (**$**),
        used for escaping.
 
-   * - :samp:`header_referer`
-     - Contents of the :samp:`Referer` request
+   * - **header_referer**
+     - Contents of the **Referer** request
        `header field
        <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer>`__.
 
-   * - :samp:`header_user_agent`
-     - Contents of the :samp:`User-Agent` request
+   * - **header_user_agent**
+     - Contents of the **User-Agent** request
        `header field
        <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent>`__.
 
-   * - :samp:`host`
-     - :samp:`Host`
+   * - **host**
+     - **Host**
        `header field
        <https://datatracker.ietf.org/doc/html/rfc9110#section-7-2>`__,
        converted to lower case and normalized
        by removing the port number
        and the trailing period (if any).
 
-   * - :samp:`method`
+   * - **method**
      - `Method <https://datatracker.ietf.org/doc/html/rfc7231#section-4>`__
        from the request line.
 
-   * - :samp:`remote_addr`
+   * - **remote_addr**
      - Remote IP address of the request.
 
-   * - :samp:`request_line`
+   * - **request_line**
      - Entire
        `request line
        <https://datatracker.ietf.org/doc/html/rfc9112#section-3>`__.
 
-   * - :samp:`request_time`
+   * - **request_time**
      - Request processing time in milliseconds,
        formatted as follows:
-       :samp:`1.234`.
+       **1.234**.
 
-   * - :samp:`request_uri`
+   * - **request_uri**
      - Request target
        `path
        <https://datatracker.ietf.org/doc/html/rfc3986#section-3-3>`__
@@ -1804,25 +1804,25 @@ There's a number of built-in variables available:
        ("." and "..")
        and collapsing adjacent slashes.
 
-   * - :samp:`response_header_*`
+   * - **response_header_***
      - Variables that store
        :ref:`response header fields
        <configuration-response-headers>`,
-       such as :samp:`response_header_content_type`.
+       such as **response_header_content_type**.
        The names of these variables are case insensitive.
 
-   * - :samp:`status`
+   * - **status**
      - HTTP
        `status code
        <https://datatracker.ietf.org/doc/html/rfc7231#section-6>`__
        of the response.
 
-   * - :samp:`time_local`
+   * - **time_local**
      - Local time,
        formatted as follows:
-       :samp:`31/Dec/1986:19:40:00 +0300`.
+       **31/Dec/1986:19:40:00 +0300**.
 
-   * - :samp:`uri`
+   * - **uri**
      - Request target
        `path
        <https://datatracker.ietf.org/doc/html/rfc3986#section-3-3>`__
@@ -1842,39 +1842,39 @@ There's a number of built-in variables available:
 
 These variables can be used with:
 
-- :samp:`pass` in
+- **pass** in
   :ref:`listeners <configuration-listeners>`
   and
   :ref:`actions <configuration-routes-action>`
   to choose between routes, applications, app targets, or upstreams.
 
-- :samp:`rewrite` in
+- **rewrite** in
   :ref:`actions <configuration-routes-action>`
   to enable :ref:`URI rewriting <configuration-rewrite>`.
 
-- :samp:`share` and :samp:`chroot` in
+- **share** and **chroot** in
   :ref:`actions <configuration-routes-action>`
   to control
   :ref:`static content serving <configuration-static>`.
 
-- :samp:`location` in :samp:`return`
+- **location** in **return**
   :ref:`actions <configuration-return>`
   to enable HTTP redirects.
 
-- :samp:`format` in the
+- **format** in the
   :ref:`access log <configuration-access-log>`
   to customize Unit's log output.
 
 
 To reference a variable,
 prefix its name with the dollar sign character
-(:samp:`$`),
+(**$**),
 optionally enclosing the name in curly brackets
-(:samp:`{}`)
+(**{}**)
 to separate it from adjacent text
 or enhance visibility.
 Variable names can contain letters and underscores
-(:samp:`_`),
+(**_**),
 so use the brackets
 if the variable is immediately followed by such characters:
 
@@ -1914,25 +1914,25 @@ if the variable is immediately followed by such characters:
        }
    }
 
-To reference an :samp:`arg_*`,
-:samp:`cookie_*`,
-or :samp:`header_*` variable,
+To reference an **arg_***,
+**cookie_***,
+or **header_*** variable,
 add the name you need to the prefix.
-A query string of :samp:`Type=car&Color=red`
+A query string of **Type=car&Color=red**
 yields two variables,
-:samp:`$arg_Type` and :samp:`$arg_Color`;
+**$arg_Type** and **$arg_Color**;
 Unit additionally normalizes capitalization and hyphenation
 in header field names,
-so the :samp:`Accept-Encoding` header field
-can also be referred to as :samp:`$header_Accept_Encoding`,
-:samp:`$header_accept-encoding`,
-or :samp:`$header_accept_encoding`.
+so the **Accept-Encoding** header field
+can also be referred to as **$header_Accept_Encoding**,
+**$header_accept-encoding**,
+or **$header_accept_encoding**.
 
 .. note::
 
    With multiple argument instances
-   (think :samp:`Color=Red&Color=Blue`),
-   the rightmost one is used (:samp:`Blue`).
+   (think **Color=Red&Color=Blue**),
+   the rightmost one is used (**Blue**).
 
 At runtime,
 variables expand into dynamically computed values
@@ -2025,7 +2025,7 @@ it is considered empty.
          $ curl http://localhost/blog     # Targets the 'blog' app
          $ curl http://localhost/sandbox  # Targets the 'sandbox' app
 
-   A different approach puts the :samp:`Host` header field
+   A different approach puts the **Host** header field
    received from the client
    to the same use:
 
@@ -2074,11 +2074,11 @@ it is considered empty.
       }
 
    At runtime,
-   a request for :samp:`example.com/myapp`
-   is passed to :samp:`applications/app_example.com/myapp`.
+   a request for **example.com/myapp**
+   is passed to **applications/app_example.com/myapp**.
 
    To select a share directory
-   based on an :samp:`app_session` cookie:
+   based on an **app_session** cookie:
 
    .. code-block:: json
 
@@ -2088,9 +2088,9 @@ it is considered empty.
           }
       }
 
-   Here, if :samp:`$uri` in :samp:`share` resolves to a directory,
+   Here, if **$uri** in **share** resolves to a directory,
    the choice of an index file to be served
-   is dictated by :samp:`index`:
+   is dictated by **index**:
 
    .. code-block:: json
 
@@ -2101,7 +2101,7 @@ it is considered empty.
           }
       }
 
-   Here, a redirect uses the :samp:`$request_uri` variable value
+   Here, a redirect uses the **$request_uri** variable value
    to relay the request,
    *including* the query part,
    to the same website over HTTPS:
@@ -2119,24 +2119,24 @@ it is considered empty.
 .. _configuration-rewrite:
 
 ***********
-URI Rewrite
+URI rewrite
 ***********
 
 All route step
 :ref:`actions <configuration-routes-action>`
-support the :samp:`rewrite` option
+support the **rewrite** option
 that updates the URI of the incoming request
 before the action is applied.
 It does not affect the
 `query
 <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__
 but changes the
-:samp:`uri` and
-:samp:`$request_uri`
+**uri** and
+**$request_uri**
 :ref:`variables <configuration-variables>`.
 
-This :samp:`match`-less action
-prefixes the request URI with :samp:`/v1`
+This **match**-less action
+prefixes the request URI with **/v1**
 and returns it to routing:
 
 .. code-block:: json
@@ -2152,8 +2152,8 @@ and returns it to routing:
 .. warning::
 
    Avoid infinite loops
-   when you  :samp:`pass` requests
-   back to :samp:`routes`.
+   when you  **pass** requests
+   back to **routes**.
 
 This action
 normalizes the request URI
@@ -2178,12 +2178,12 @@ and passes it to an application:
 .. _configuration-response-headers:
 
 ****************
-Response Headers
+Response headers
 ****************
 
 All route step
 :ref:`actions <configuration-routes-action>`
-support the :samp:`response_headers` option
+support the **response_headers** option
 that updates the header fields of Unit's response
 before the action is taken:
 
@@ -2199,8 +2199,8 @@ before the action is taken:
        }
    }
 
-This works only for the :samp:`2XX` and :samp:`3XX` responses;
-also, :samp:`Date`, :samp:`Server`, and :samp:`Content-Length` can't be set.
+This works only for the **2XX** and **3XX** responses;
+also, **Date**, **Server**, and **Content-Length** can't be set.
 
 The option sets given string values
 for the header fields of the response
@@ -2212,7 +2212,7 @@ that Unit will send for the specific request:
 
 - If a header field with this name is already set, its value is updated.
 
-- If :samp:`null` is supplied for the value, the header field is *deleted*.
+- If **null** is supplied for the value, the header field is *deleted*.
 
 If the action is taken and Unit issues a response,
 it sends the header fields *this specific* action specifies.
@@ -2232,16 +2232,16 @@ which enables arbitrary runtime logic:
        "Content-Language": "`${ uri.startsWith('/uk') ? 'en-GB' : 'en-US' }`"
    }
 
-Finally, there are the :samp:`response_header_*` variables
+Finally, there are the **response_header_*** variables
 that evaluate to the header field values set with the response
 (by the app, upstream, or Unit itself;
 the latter is the case with
-:samp:`$response_header_connection`,
-:samp:`$response_header_content_length`,
-and :samp:`$response_header_transfer_encoding`).
+**$response_header_connection**,
+**$response_header_content_length**,
+and **$response_header_transfer_encoding**).
 
 One use is to update the headers in the final response;
-this extends the :samp:`Content-Type` issued by the app:
+this extends the **Content-Type** issued by the app:
 
 .. code-block:: json
 
@@ -2260,7 +2260,7 @@ Alternatively, they will come in handy with
 .. _configuration-return:
 
 ****************************
-Instant Responses, Redirects
+Instant responses, redirects
 ****************************
 
 You can use route step
@@ -2282,18 +2282,18 @@ with arbitrary
        }
    }
 
-The :samp:`return` action provides the following options:
+The **return** action provides the following options:
 
 .. list-table::
 
-   * - :samp:`return` (required)
+   * - **return** (required)
      - Integer (000–999);
        defines the HTTP response status code
        to be returned.
 
-   * - :samp:`location`
+   * - **location**
      - String URI;
-       used if the :samp:`return` value implies redirection.
+       used if the **return** value implies redirection.
 
 Use the codes according to their intended
 `semantics
@@ -2303,8 +2303,8 @@ make sure that user agents can understand them.
 
 If you specify a redirect code (3xx),
 supply the destination
-using the :samp:`location` option
-alongside :samp:`return`:
+using the **location** option
+alongside **return**:
 
 .. code-block:: json
 
@@ -2316,7 +2316,7 @@ alongside :samp:`return`:
    }
 
 Besides enriching the response semantics,
-:samp:`return` simplifies :ref:`allow-deny lists <allow-deny>`:
+**return** simplifies :ref:`allow-deny lists <allow-deny>`:
 instead of guarding each action with a filter,
 add
 :ref:`conditions <configuration-routes-matching>`
@@ -2355,7 +2355,7 @@ for example:
 .. _configuration-static:
 
 ************
-Static Files
+Static files
 ************
 
 Unit is capable of acting as a standalone web server,
@@ -2363,39 +2363,39 @@ efficiently serving static files
 from the local file system;
 to use the feature,
 list the file paths
-in the :samp:`share` option
+in the **share** option
 of a route step
 :ref:`action
 <configuration-routes-action>`.
 
-A :samp:`share`-based action provides the following options:
+A **share**-based action provides the following options:
 
 .. list-table::
 
-   * - :samp:`share` (required)
+   * - **share** (required)
      - String or an array of strings;
        lists file paths that are tried
        until a file is found.
        When no file is found,
-       :samp:`fallback` is used if set.
+       **fallback** is used if set.
 
        The value is
        :ref:`variable <configuration-variables>`-interpolated.
 
-   * - :samp:`index`
+   * - **index**
      - Filename;
-       tried if :samp:`share` is a directory.
+       tried if **share** is a directory.
        When no file is found,
-       :samp:`fallback` is used if set.
+       **fallback** is used if set.
 
-       The default is :file:`index.html`.
+       The default is **index.html**.
 
-   * - :samp:`fallback`
+   * - **fallback**
      - Action-like :ref:`object <configuration-fallback>`;
        used if the request
-       can't be served by :samp:`share` or :samp:`index`.
+       can't be served by **share** or **index**.
 
-   * - :samp:`types`
+   * - **types**
      - :ref:`Array <configuration-share-mime>`
        of
        `MIME type
@@ -2403,7 +2403,7 @@ A :samp:`share`-based action provides the following options:
        patterns;
        used to filter the shared files.
 
-   * - :samp:`chroot`
+   * - **chroot**
      - Directory pathname that
        :ref:`restricts <configuration-share-path>`
        the shareable paths.
@@ -2411,17 +2411,17 @@ A :samp:`share`-based action provides the following options:
        The value is
        :ref:`variable <configuration-variables>`-interpolated.
 
-   * - :samp:`follow_symlinks`, :samp:`traverse_mounts`
+   * - **follow_symlinks**, **traverse_mounts**
      - Booleans;
        turn on and off symbolic link and mount point
        :ref:`resolution <configuration-share-resolution>`
        respectively;
-       if :samp:`chroot` is set,
+       if **chroot** is set,
        they only
        :ref:`affect <configuration-share-path>`
-       the insides of :samp:`chroot`.
+       the insides of **chroot**.
 
-       The default for both options is :samp:`true`
+       The default for both options is **true**
        (resolve links and mounts).
 
 .. note::
@@ -2434,7 +2434,7 @@ A :samp:`share`-based action provides the following options:
    When Unit is installed from the
    :ref:`official packages
    <installation-precomp-pkgs>`,
-   the process runs as :samp:`unit:unit`;
+   the process runs as **unit:unit**;
    for details of other installation methods,
    see :doc:`installation`.
 
@@ -2460,7 +2460,7 @@ Consider the following configuration:
 
 It uses
 :ref:`variable interpolation <configuration-variables>`:
-Unit replaces the :samp:`$uri` reference
+Unit replaces the **$uri** reference
 with its current value
 and tries the resulting path.
 If this doesn't yield a servable file,
@@ -2469,11 +2469,11 @@ a 404 "Not Found" response is returned.
 .. warning::
 
    Before version 1.26.0,
-   Unit used :samp:`share` as the document root.
+   Unit used **share** as the document root.
    This was changed for flexibility,
-   so now :samp:`share` must resolve to specific files.
+   so now **share** must resolve to specific files.
    A common solution is
-   to append :samp:`$uri` to your document root.
+   to append **$uri** to your document root.
 
    Pre-1.26,
    the snippet above would've looked like this:
@@ -2486,12 +2486,12 @@ a 404 "Not Found" response is returned.
 
    Mind that URI paths always start with a slash,
    so there's no need to separate the directory
-   from :samp:`$uri`;
+   from **$uri**;
    even if you do, Unit compacts adjacent slashes
    during path resolution,
    so there won't be an issue.
 
-If :samp:`share` is an array,
+If **share** is an array,
 its items are searched in order of appearance
 until a servable file is found:
 
@@ -2502,14 +2502,14 @@ until a servable file is found:
        "/www/error_pages/not_found.html"
    ]
 
-This snippet tries a :samp:`$host`-based directory first;
+This snippet tries a **$host**-based directory first;
 if a suitable file isn't found there,
-the :file:`not_found.html` file is tried.
+the **not_found.html** file is tried.
 If neither is accessible,
 a 404 "Not Found" response is returned.
 
 Finally, if a file path points to a directory,
-Unit attempts to serve an :samp:`index`-indicated file from it.
+Unit attempts to serve an **index**-indicated file from it.
 Suppose we have the following directory structure
 and share configuration:
 
@@ -2526,7 +2526,7 @@ and share configuration:
        "index": "default.html"
    }
 
-The following request returns :file:`default.html`
+The following request returns **default.html**
 even though the file isn't named explicitly:
 
 .. subs-code-block:: console
@@ -2544,22 +2544,22 @@ even though the file isn't named explicitly:
 .. note::
 
    Unit's ETag response header fields
-   use the :samp:`MTIME-FILESIZE` format,
-   where :samp:`MTIME` stands for file modification timestamp
-   and :samp:`FILESIZE` stands for file size in bytes,
+   use the **MTIME-FILESIZE** format,
+   where **MTIME** stands for file modification timestamp
+   and **FILESIZE** stands for file size in bytes,
    both in hexadecimal.
 
 
 .. _configuration-share-mime:
 
 ==============
-MIME Filtering
+MIME filtering
 ==============
 
-To filter the files a :samp:`share` serves
+To filter the files a **share** serves
 by their
 `MIME types <https://www.iana.org/assignments/media-types/media-types.xhtml>`__,
-define a :samp:`types` array of string patterns.
+define a **types** array of string patterns.
 They work like
 :ref:`route patterns
 <configuration-routes-matching-patterns>`
@@ -2584,7 +2584,7 @@ This sample configuration blocks JS and CSS files with
 :ref:`negation <configuration-routes-matching-resolution>`
 but allows all other text-based MIME types with a
 :ref:`wildcard pattern <configuration-routes-matching-patterns>`.
-Additionally, the :file:`.3gpp` and :file:`.3gpp2` file types
+Additionally, the **.3gpp** and **.3gpp2** file types
 are allowed by a
 :ref:`regex pattern <configuration-routes-matching-patterns>`.
 
@@ -2614,8 +2614,8 @@ and proxies are informed that this content should be cached.
 
 If the MIME type of a requested file isn't recognized,
 it's considered empty
-(:samp:`""`).
-Thus, the :samp:`"!"` pattern
+(**""**).
+Thus, the **"!"** pattern
 ("deny empty strings")
 can be used to restrict all file types
 :ref:`unknown <configuration-mime>`
@@ -2637,7 +2637,7 @@ Unit *doesn't* apply MIME filtering.
 .. _configuration-share-path:
 
 =================
-Path Restrictions
+Path restrictions
 =================
 
 .. note::
@@ -2646,12 +2646,12 @@ Path Restrictions
    Unit must be built and run
    on a system with Linux kernel version 5.6+.
 
-The :samp:`chroot` option confines the path resolution
+The **chroot** option confines the path resolution
 within a share to a certain directory.
 First, it affects symbolic links:
 any attempts to go up the directory tree
-with relative symlinks like :samp:`../../var/log`
-stop at the :samp:`chroot` directory,
+with relative symlinks like **../../var/log**
+stop at the **chroot** directory,
 and absolute symlinks are treated as relative
 to this directory to avoid breaking out:
 
@@ -2664,13 +2664,13 @@ to this directory to avoid breaking out:
        }
    }
 
-Here, a request for :file:`/log`
-initially resolves to :file:`/www/data/log`;
-however, if that's an absolute symlink to :file:`/var/log/app.log`,
-the resulting path is :file:`/www/data/var/log/app.log`.
+Here, a request for **/log**
+initially resolves to **/www/data/log**;
+however, if that's an absolute symlink to **/var/log/app.log**,
+the resulting path is **/www/data/var/log/app.log**.
 
 Another effect is that any requests
-for paths that resolve outside the :samp:`chroot` directory
+for paths that resolve outside the **chroot** directory
 are forbidden:
 
 .. code-block:: json
@@ -2682,17 +2682,17 @@ are forbidden:
        }
    }
 
-Here, a request for :samp:`/index.xml`
+Here, a request for **/index.xml**
 elicits a 403 "Forbidden" response
-because it resolves to :samp:`/www/index.xml`,
-which is outside :samp:`chroot`.
+because it resolves to **/www/index.xml**,
+which is outside **chroot**.
 
 .. _configuration-share-resolution:
 
-The :samp:`follow_symlinks` and :samp:`traverse_mounts` options
+The **follow_symlinks** and **traverse_mounts** options
 disable resolution of symlinks and traversal of mount points
-when set to :samp:`false`
-(both default to :samp:`true`):
+when set to **false**
+(both default to **true**):
 
 .. code-block:: json
 
@@ -2704,12 +2704,12 @@ when set to :samp:`false`
        }
    }
 
-Here, any symlink or mount point in the entire :samp:`share` path
+Here, any symlink or mount point in the entire **share** path
 results in a 403 "Forbidden" response.
 
-With :samp:`chroot` set,
-:samp:`follow_symlinks` and :samp:`traverse_mounts`
-only affect portions of the path *after* :samp:`chroot`:
+With **chroot** set,
+**follow_symlinks** and **traverse_mounts**
+only affect portions of the path *after* **chroot**:
 
 .. code-block:: json
 
@@ -2722,10 +2722,10 @@ only affect portions of the path *after* :samp:`chroot`:
        }
    }
 
-Here, :file:`www/` and interpolated :samp:`$host`
+Here, **www/** and interpolated **$host**
 can be symlinks or mount points,
 but any symlinks and mount points beyond them,
-including the :file:`static/` portion,
+including the **static/** portion,
 won't be resolved.
 
 .. nxt_details:: Details
@@ -2733,7 +2733,7 @@ won't be resolved.
 
    Suppose you want to serve files from a share
    that itself includes a symlink
-   (let's assume :samp:`$host` always resolves to :samp:`localhost`
+   (let's assume **$host** always resolves to **localhost**
    and make it a symlink in our example)
    but disable any symlinks inside the share.
 
@@ -2748,7 +2748,7 @@ won't be resolved.
           }
       }
 
-   Create a symlink to :file:`/www/localhost/static/index.html`:
+   Create a symlink to **/www/localhost/static/index.html**:
 
    .. code-block:: console
 
@@ -2761,7 +2761,7 @@ won't be resolved.
       $ ln -s index.html /www/localhost/static/symlink
 
    If symlink resolution is enabled
-   (with or without :samp:`chroot`),
+   (with or without **chroot**),
    a request that targets the symlink works:
 
    .. code-block:: console
@@ -2774,7 +2774,7 @@ won't be resolved.
 
             index.html
 
-   Now set :samp:`follow_symlinks` to :samp:`false`:
+   Now set **follow_symlinks** to **false**:
 
    .. code-block:: json
 
@@ -2799,7 +2799,7 @@ won't be resolved.
 
             <!DOCTYPE html><title>Error 403</title><p>Error 403.
 
-   Lastly, what difference does :samp:`chroot` make?
+   Lastly, what difference does **chroot** make?
    To see, remove it:
 
    .. code-block:: json
@@ -2811,8 +2811,8 @@ won't be resolved.
           }
       }
 
-   Now, :samp:`"follow_symlinks": false` affects the entire share,
-   and :samp:`localhost` is a symlink,
+   Now, **"follow_symlinks": false** affects the entire share,
+   and **localhost** is a symlink,
    so it's forbidden:
 
    .. code-block:: console
@@ -2825,17 +2825,17 @@ won't be resolved.
 .. _configuration-fallback:
 
 ===============
-Fallback Action
+Fallback action
 ===============
 
-Finally, within an :samp:`action`,
-you can supply a :samp:`fallback` option
-beside a :samp:`share`.
+Finally, within an **action**,
+you can supply a **fallback** option
+beside a **share**.
 It specifies the
 :ref:`action <configuration-routes-action>`
 to be taken
 if the requested file can't be served
-from the :samp:`share` path:
+from the **share** path:
 
 .. code-block:: json
 
@@ -2848,12 +2848,12 @@ from the :samp:`share` path:
 
 Serving a file can be impossible for different reasons, such as:
 
-- The request's HTTP method isn't :samp:`GET` or :samp:`HEAD`.
+- The request's HTTP method isn't **GET** or **HEAD**.
 
-- The file's MIME type doesn't match the :samp:`types`
+- The file's MIME type doesn't match the **types**
   :ref:`array <configuration-share-mime>`.
 
-- The file isn't found at the :samp:`share` path.
+- The file isn't found at the **share** path.
 
 - The router process has
   :ref:`insufficient permissions <security-apps>`
@@ -2861,13 +2861,13 @@ Serving a file can be impossible for different reasons, such as:
 
 In the previous example,
 an attempt to serve the requested file
-from the :samp:`/www/data/static/` directory
+from the **/www/data/static/** directory
 is made first.
 Only if the file can't be served,
-the request is passed to the :samp:`php` application.
+the request is passed to the **php** application.
 
-If the :samp:`fallback` itself is a :samp:`share`,
-it can also contain a nested :samp:`fallback`:
+If the **fallback** itself is a **share**,
+it can also contain a nested **fallback**:
 
 .. code-block:: json
 
@@ -2882,10 +2882,10 @@ it can also contain a nested :samp:`fallback`:
        }
    }
 
-The first :samp:`share` tries to serve the request
-from :file:`/www/data/static/`;
-on failure, the second :samp:`share` tries the :file:`/www/cache/` path
-with :samp:`chroot` enabled.
+The first **share** tries to serve the request
+from **/www/data/static/**;
+on failure, the second **share** tries the **/www/cache/** path
+with **chroot** enabled.
 If both attempts fail,
 the request is proxied elsewhere.
 
@@ -2897,10 +2897,10 @@ the request is proxied elsewhere.
    for static and dynamic content
    into independent routes.
    The following example relays all requests
-   that target :file:`.php` files
+   that target **.php** files
    to an application
-   and uses a catch-all static :samp:`share`
-   with a :samp:`fallback`:
+   and uses a catch-all static **share**
+   with a **fallback**:
 
    .. code-block:: json
 
@@ -2937,8 +2937,8 @@ the request is proxied elsewhere.
    You can reverse this scheme for apps
    that avoid filenames in dynamic URIs,
    listing all types of static content
-   to be served from a :samp:`share`
-   in a :samp:`match` condition
+   to be served from a **share**
+   in a **match** condition
    and adding an unconditional application path:
 
    .. code-block:: json
@@ -2982,7 +2982,7 @@ the request is proxied elsewhere.
 
    If image files should be served locally
    and other proxied,
-   use the :samp:`types` array
+   use the **types** array
    in the first route step:
 
    .. code-block:: json
@@ -3012,7 +3012,7 @@ the request is proxied elsewhere.
       }
 
    Another way to combine
-   :samp:`share`, :samp:`types`, and :samp:`fallback`
+   **share**, **types**, and **fallback**
    is exemplified by the following compact pattern:
 
    .. code-block:: json
@@ -3032,7 +3032,7 @@ the request is proxied elsewhere.
    to the app
    while serving all other types of files
    from the share;
-   note that a :samp:`match` object
+   note that a **match** object
    isn't needed here to achieve this effect.
 
 
@@ -3044,7 +3044,7 @@ Proxying
 
 Unit's routes support HTTP proxying
 to socket addresses
-using the :samp:`proxy` option
+using the **proxy** option
 of a route step
 :ref:`action <configuration-routes-action>`:
 
@@ -3094,21 +3094,21 @@ for proxy destinations.
 .. _configuration-upstreams:
 
 ==============
-Load Balancing
+Load balancing
 ==============
 
 Besides proxying requests to individual servers,
 Unit can also relay incoming requests to *upstreams*.
 An upstream is a group of servers
 that comprise a single logical entity
-and may be used as a :samp:`pass` destination
+and may be used as a **pass** destination
 for incoming requests in a
 :ref:`listener <configuration-listeners>`
 or a
 :ref:`route <configuration-routes>`.
 
 Upstreams are defined
-in the eponymous :samp:`/config/upstreams` section of the API:
+in the eponymous **/config/upstreams** section of the API:
 
 .. code-block:: json
 
@@ -3131,18 +3131,18 @@ in the eponymous :samp:`/config/upstreams` section of the API:
        }
    }
 
-An upstream must define a :samp:`servers` object
+An upstream must define a **servers** object
 that lists socket addresses
 as server object names.
 Unit dispatches requests between the upstream's servers
 in a round-robin fashion,
 acting as a load balancer.
-Each server object can set a numeric :samp:`weight`
+Each server object can set a numeric **weight**
 to adjust the share of requests
 it receives via the upstream.
 In the above example,
-:samp:`192.168.0.100:8080` receives twice as many requests
-as :samp:`192.168.0.101:8080`.
+**192.168.0.100:8080** receives twice as many requests
+as **192.168.0.101:8080**.
 
 Weights can be specified as integers or fractions
 in decimal or scientific notation:
@@ -3165,10 +3165,10 @@ in decimal or scientific notation:
        }
    }
 
-The maximum weight is :samp:`1000000`,
-the minimum is :samp:`0`
+The maximum weight is **1000000**,
+the minimum is **0**
 (such servers receive no requests);
-the default is :samp:`1`.
+the default is **1**.
 
 
 .. _configuration-applications:
@@ -3179,7 +3179,7 @@ Applications
 
 Each app that Unit runs
 is defined as an object
-in the :samp:`/config/applications` section of the control API;
+in the **/config/applications** section of the control API;
 it lists the app's language and settings,
 its runtime limits,
 process model,
@@ -3191,11 +3191,11 @@ and various language-specific options.
    :ref:`language-specific packages <installation-precomp-pkgs>`
    include end-to-end examples of application configuration,
    available for your reference at
-   :file:`/usr/share/doc/<module name>/examples/`
+   **/usr/share/doc/<module name>/examples/**
    after package installation.
 
-Here, Unit runs 20 processes of a PHP app called :samp:`blogs`,
-stored in the :file:`/www/blogs/scripts/` directory:
+Here, Unit runs 20 processes of a PHP app called **blogs**,
+stored in the **/www/blogs/scripts/** directory:
 
 .. code-block:: json
 
@@ -3218,86 +3218,86 @@ shared between all application languages:
     * - Option
       - Description
 
-    * - :samp:`type` (required)
+    * - **type** (required)
       - Application type:
-        :samp:`external`
+        **external**
         (Go and Node.js),
-        :samp:`java`,
-        :samp:`perl`,
-        :samp:`php`,
-        :samp:`python`,
-        :samp:`ruby`,
-        or :samp:`wasm`
+        **java**,
+        **perl**,
+        **php**,
+        **python**,
+        **ruby**,
+        or **wasm**
         (WebAssembly).
 
-        Except for :samp:`external` and :samp:`wasm`,
+        Except for **external** and **wasm**,
         you can detail the runtime version:
-        :samp:`"type": "python 3"`,
-        :samp:`"type": "python 3.4"`,
+        **"type": "python 3"**,
+        **"type": "python 3.4"**,
         or even
-        :samp:`"type": "python 3.4.9rc1"`.
+        **"type": "python 3.4.9rc1"**.
         Unit searches its modules
         and uses the latest matching one,
         reporting an error if none match.
 
         For example, if you have only one PHP module,
         7.1.9,
-        it matches :samp:`"php"`,
-        :samp:`"php 7"`,
-        :samp:`"php 7.1"`,
-        and :samp:`"php 7.1.9"`.
+        it matches **"php"**,
+        **"php 7"**,
+        **"php 7.1"**,
+        and **"php 7.1.9"**.
         If you have modules for versions 7.0.2 and 7.0.23,
-        set :samp:`"type": "php 7.0.2"` to specify the former;
+        set **"type": "php 7.0.2"** to specify the former;
         otherwise, PHP |_| 7.0.23 will be used.
 
-    * - :samp:`environment`
+    * - **environment**
       - String-valued object;
         environment variables to be passed to the app.
 
-    * - :samp:`group`
+    * - **group**
       - String;
         group name that runs the
         :ref:`app process <sec-processes>`.
 
-        The default is the :samp:`user`'s primary group.
+        The default is the **user**'s primary group.
 
-    * - :samp:`isolation`
+    * - **isolation**
       - Object; manages the isolation
         of an application process.
         For details, see
         :ref:`here <configuration-proc-mgmt-isolation>`.
 
-    * - :samp:`limits`
+    * - **limits**
       - Object; accepts two integer options,
-        :samp:`timeout` and :samp:`requests`.
+        **timeout** and **requests**.
         Their values govern the life cycle of an application process.
         For details, see
         :ref:`here <configuration-proc-mgmt-lmts>`.
 
-    * - :samp:`processes`
+    * - **processes**
       - Integer or object;
         integer sets a static number of app processes,
-        and object options :samp:`max`,
-        :samp:`spare`,
-        and :samp:`idle_timeout`
+        and object options **max**,
+        **spare**,
+        and **idle_timeout**
         enable dynamic management.
         For details, see
         :ref:`here <configuration-proc-mgmt-prcs>`.
 
         The default is 1.
 
-    * - :samp:`stderr`, :samp:`stdout`
+    * - **stderr**, **stdout**
       - Strings;
         filenames where Unit redirects
         the application's output.
 
-        The default is :file:`/dev/null`.
+        The default is **/dev/null**.
 
-        When running in :samp:`--no-daemon` mode, application output
+        When running in **--no-daemon** mode, application output
         is always redirected to
         :ref:`Unit's log file <troubleshooting-log>`.
 
-    * - :samp:`user`
+    * - **user**
       - String;
         username that runs the
         :ref:`app process <sec-processes>`.
@@ -3307,7 +3307,7 @@ shared between all application languages:
         or at
         :ref:`startup <source-startup>`.
 
-    * - :samp:`working_directory`
+    * - **working_directory**
       - String;
         the app's working directory.
 
@@ -3316,11 +3316,11 @@ shared between all application languages:
         of Unit's
         :ref:`main process <sec-processes>`.
 
-Also, you need to set :samp:`type`-specific options
+Also, you need to set **type**-specific options
 to run the app.
 This
 :ref:`Python app <configuration-python>`
-sets :samp:`path` and :samp:`module`:
+sets **path** and **module**:
 
 .. code-block:: json
 
@@ -3345,14 +3345,14 @@ sets :samp:`path` and :samp:`module`:
 .. _configuration-proc-mgmt:
 
 ==================
-Process Management
+Process management
 ==================
 
 Unit has three per-app options
 that control how the app's processes behave:
-:samp:`isolation`, :samp:`limits`, and :samp:`processes`.
-Also, you can :samp:`GET`
-the :samp:`/control/applications/` section of the API
+**isolation**, **limits**, and **processes**.
+Also, you can **GET**
+the **/control/applications/** section of the API
 to restart an app:
 
 .. code-block:: console
@@ -3364,13 +3364,13 @@ Unit handles the rollover gracefully,
 allowing the old processes
 to deal with existing requests
 and starting a new set of processes
-(as defined by the :samp:`processes`
+(as defined by the **processes**
 :ref:`option <configuration-proc-mgmt-prcs>`)
 to accept new requests.
 
 .. _configuration-proc-mgmt-isolation:
 
-Process Isolation
+Process isolation
 *****************
 
 You can use
@@ -3386,7 +3386,7 @@ if Unit's underlying OS supports them:
 
        cgroup :nxt_hint:`mnt <The mount namespace>` :nxt_hint:`net <The network namespace>` pid ... :nxt_hint:`user <The credential namespace>` :nxt_hint:`uts <The uname namespace>`
 
-The :samp:`isolation` application option
+The **isolation** application option
 has the following members:
 
 .. list-table::
@@ -3395,19 +3395,19 @@ has the following members:
    * - Option
      - Description
 
-   * - :samp:`automount`
+   * - **automount**
      - Object;
        controls mount behavior
-       if :samp:`rootfs` is enabled.
+       if **rootfs** is enabled.
        By default, Unit automatically mounts the
        :ref:`language runtime dependencies <conf-rootfs>`,
        a
        `procfs
        <https://man7.org/linux/man-pages/man5/procfs.5.html>`__
-       at :file:`/proc/`,
+       at **/proc/**,
        and a
        `tmpfs
-       <https://man7.org/linux/man-pages/man5/tmpfs.5.html>`__ at :file:`/tmp/`,
+       <https://man7.org/linux/man-pages/man5/tmpfs.5.html>`__ at **/tmp/**,
        but you can disable any of these default mounts:
 
        .. code-block:: json
@@ -3422,7 +3422,7 @@ has the following members:
               }
           }
 
-   * - :samp:`cgroup`
+   * - **cgroup**
      - Object;
        defines the app's
        :ref:`cgroup <conf-app-cgroup>`.
@@ -3433,7 +3433,7 @@ has the following members:
           * - Option
             - Description
 
-          * - :samp:`path` (required)
+          * - **path** (required)
             - String;
               configures absolute or relative path of the app
               in the
@@ -3442,11 +3442,11 @@ has the following members:
               The limits trickle down the hierarchy,
               so child cgroups can't exceed parental thresholds.
 
-   * - :samp:`gidmap`
-     - Same as :samp:`uidmap`,
+   * - **gidmap**
+     - Same as **uidmap**,
        but configures group IDs instead of user IDs.
 
-   * - :samp:`namespaces`
+   * - **namespaces**
      - Object; configures
        `namespace <https://man7.org/linux/man-pages/man7/namespaces.7.html>`__
        isolation scheme for the application.
@@ -3457,37 +3457,37 @@ has the following members:
 
        .. list-table::
 
-          * - :samp:`cgroup`
+          * - **cgroup**
             - Creates a new
               `cgroup
               <https://man7.org/linux/man-pages/man7/cgroup_namespaces.7.html>`__
               namespace for the app.
 
-          * - :samp:`credential`
+          * - **credential**
             - Creates a new
               `user
               <https://man7.org/linux/man-pages/man7/user_namespaces.7.html>`__
               namespace for the app.
 
-          * - :samp:`mount`
+          * - **mount**
             - Creates a new
               `mount
               <https://man7.org/linux/man-pages/man7/mount_namespaces.7.html>`__
               namespace for the app.
 
-          * - :samp:`network`
+          * - **network**
             - Creates a new
               `network
               <https://man7.org/linux/man-pages/man7/network_namespaces.7.html>`__
               namespace for the app.
 
-          * - :samp:`pid`
+          * - **pid**
             - Creates a new
               `PID
               <https://man7.org/linux/man-pages/man7/pid_namespaces.7.html>`__
               namespace for the app.
 
-          * - :samp:`uname`
+          * - **uname**
             - Creates a new
               `UTS
               <https://man7.org/linux/man-pages/man7/namespaces.7.html>`__
@@ -3495,41 +3495,41 @@ has the following members:
 
        All options listed above are Boolean;
        to isolate the app,
-       set the corresponding namespace option to :samp:`true`;
+       set the corresponding namespace option to **true**;
        to disable isolation,
-       set the option to :samp:`false`
+       set the option to **false**
        (default).
 
-   * - :samp:`rootfs`
+   * - **rootfs**
      - String; pathname of the directory
        to be used as the new
        :ref:`file system root
        <conf-rootfs>`
        for the app.
 
-   * - :samp:`uidmap`
+   * - **uidmap**
      - Array of user ID
        :ref:`mapping objects <conf-uidgid-mapping>`;
        each array item must define the following:
 
        .. list-table::
 
-          * - :samp:`container`
+          * - **container**
             - Integer;
               starts the user ID mapping range
               in the app's namespace.
 
-          * - :samp:`host`
+          * - **host**
             - Integer;
               starts the user ID mapping range
               in the OS namespace.
 
-          * - :samp:`size`
+          * - **size**
             - Integer;
               size of the ID range
               in both namespaces.
 
-A sample :samp:`isolation` object
+A sample **isolation** object
 that enables all namespaces
 and sets mappings for user and group IDs:
 
@@ -3569,7 +3569,7 @@ and sets mappings for user and group IDs:
 
 .. _conf-app-cgroup:
 
-Using Control Groups
+Using control groups
 ====================
 
 A control group (cgroup) commands
@@ -3580,12 +3580,12 @@ Cgroups are defined
 by their *paths*
 in the cgroups file system.
 
-The :samp:`cgroup` object
+The **cgroup** object
 defines the cgroup
 for a Unit app;
-its :samp:`path` option
+its **path** option
 can set an absolute
-(starting with :samp:`/`)
+(starting with **/**)
 or a relative value.
 If the path doesn't exist
 in the cgroups file system,
@@ -3595,7 +3595,7 @@ Relative paths are implicitly placed
 inside the cgroup of Unit's
 :ref:`main process <sec-processes>`;
 this setting effectively puts the app
-to the :file:`/<main Unit process cgroup>/production/app` cgroup:
+to the **/<main Unit process cgroup>/production/app** cgroup:
 
 .. code-block:: json
 
@@ -3609,7 +3609,7 @@ to the :file:`/<main Unit process cgroup>/production/app` cgroup:
 
 An absolute pathname places the application
 under a separate cgroup subtree;
-this configuration puts the app under :file:`/staging/app`:
+this configuration puts the app under **/staging/app**:
 
 .. code-block:: json
 
@@ -3633,7 +3633,7 @@ find the cgroup mount point:
        cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
 
 Next, check the available controllers
-and set the :samp:`memory.high` limit:
+and set the **memory.high** limit:
 
 .. code-block:: console
 
@@ -3652,18 +3652,18 @@ refer to the
 .. note::
 
    To avoid confusion,
-   mind that the :samp:`namespaces/cgroups` option
+   mind that the **namespaces/cgroups** option
    controls the application's cgroup *namespace*;
-   instead, the :samp:`cgroup/path` option
+   instead, the **cgroup/path** option
    specifies the cgroup where Unit puts the application.
 
 
 .. _conf-rootfs:
 
-Changing Root Directory
+Changing root directory
 =======================
 
-The :samp:`rootfs` option confines the app
+The **rootfs** option confines the app
 to the directory you provide,
 making it the new
 `file system root
@@ -3671,13 +3671,13 @@ making it the new
 To use it,
 your app should have the corresponding privilege
 (effectively,
-run as :samp:`root` in most cases).
+run as **root** in most cases).
 
 The root directory is changed
 before the language module starts the app,
 so any path options for the app
 should be relative to the new root.
-Note the :samp:`path` and :samp:`home` settings:
+Note the **path** and **home** settings:
 
 .. code-block:: json
 
@@ -3693,8 +3693,8 @@ Note the :samp:`path` and :samp:`home` settings:
 
 .. warning::
 
-   When using :samp:`rootfs`
-   with :samp:`credential` set to :samp:`true`:
+   When using **rootfs**
+   with **credential** set to **true**:
 
    .. code-block:: json
 
@@ -3706,7 +3706,7 @@ Note the :samp:`path` and :samp:`home` settings:
       }
 
    Ensure that the user the app *runs as*
-   can access the :samp:`rootfs` directory.
+   can access the **rootfs** directory.
 
 Unit mounts language-specific files and directories
 to the new root
@@ -3719,14 +3719,14 @@ so the app stays operational:
      - Language-Specific Mounts
 
    * - Java
-     - - JVM's :file:`libc.so` directory
+     - - JVM's **libc.so** directory
 
        - Java module's
          :ref:`home <howto/source-modules-java>`
          directory
 
    * - Python
-     - Python's :samp:`sys.path`
+     - Python's **sys.path**
        `directories
        <https://docs.python.org/3/library/sys.html#sys.path>`__
 
@@ -3734,35 +3734,35 @@ so the app stays operational:
      - - Ruby's header, interpreter, and library
          `directories
          <https://idiosyncratic-ruby.com/42-ruby-config.html>`__:
-         :samp:`rubyarchhdrdir`,
-         :samp:`rubyhdrdir`,
-         :samp:`rubylibdir`,
-         :samp:`rubylibprefix`,
-         :samp:`sitedir`,
-         and :samp:`topdir`
+         **rubyarchhdrdir**,
+         **rubyhdrdir**,
+         **rubylibdir**,
+         **rubylibprefix**,
+         **sitedir**,
+         and **topdir**
 
        - Ruby's gem installation directory
-         (:samp:`gem env gemdir`)
+         (**gem env gemdir**)
 
        - Ruby's entire gem path list
-         (:samp:`gem env gempath`)
+         (**gem env gempath**)
 
 
 .. nxt_details:: Using "uidmap", "gidmap"
    :hash: conf-uidgid-mapping
 
-   The :samp:`uidmap` and :samp:`gidmap` options
+   The **uidmap** and **gidmap** options
    are available only
    if the underlying OS supports
    `user namespaces
    <https://man7.org/linux/man-pages/man7/user_namespaces.7.html>`__.
 
-   If :samp:`uidmap` is omitted but :samp:`credential` isolation is enabled,
+   If **uidmap** is omitted but **credential** isolation is enabled,
    the effective UID (EUID) of the application process
    in the host namespace
    is mapped to the same UID
    in the container namespace;
-   the same applies to :samp:`gidmap` and GID, respectively.
+   the same applies to **gidmap** and GID, respectively.
    This means that the configuration below:
 
    .. code-block:: json
@@ -3777,7 +3777,7 @@ so the app stays operational:
       }
 
    Is equivalent to the following
-   (assuming :samp:`some_user`'s EUID and EGID are both equal to 1000):
+   (assuming **some_user**'s EUID and EGID are both equal to 1000):
 
    .. code-block:: json
 
@@ -3809,10 +3809,10 @@ so the app stays operational:
 
 .. _configuration-proc-mgmt-lmts:
 
-Request Limits
+Request limits
 **************
 
-The :samp:`limits` object
+The **limits** object
 controls request handling by the app process
 and has two integer options:
 
@@ -3822,7 +3822,7 @@ and has two integer options:
    * - Option
      - Description
 
-   * - :samp:`requests`
+   * - **requests**
      - Integer;
        maximum number of requests
        an app process can serve.
@@ -3831,7 +3831,7 @@ and has two integer options:
        this mitigates possible memory leaks
        or other cumulative issues.
 
-   * - :samp:`timeout`
+   * - **timeout**
      - Integer;
        request timeout in seconds.
        If an app process exceeds it
@@ -3862,10 +3862,10 @@ Example:
 
 .. _configuration-proc-mgmt-prcs:
 
-Application Processes
+Application processes
 *********************
 
-The :samp:`processes` option
+The **processes** option
 offers a choice
 between static and dynamic process management.
 If you set it to an integer,
@@ -3873,7 +3873,7 @@ Unit immediately launches the given number of app processes
 and keeps them without scaling.
 
 To enable a dynamic prefork model for your app,
-supply a :samp:`processes` object with the following options:
+supply a **processes** object with the following options:
 
 .. list-table::
     :header-rows: 1
@@ -3881,36 +3881,36 @@ supply a :samp:`processes` object with the following options:
     * - Option
       - Description
 
-    * - :samp:`idle_timeout`
+    * - **idle_timeout**
       - Number of seconds
         Unit waits for
         before terminating an idle process
-        that exceeds :samp:`spare`.
+        that exceeds **spare**.
 
-    * - :samp:`max`
+    * - **max**
       - Maximum number of application processes
         that Unit maintains
         (busy and idle).
 
         The default is 1.
 
-    * - :samp:`spare`
+    * - **spare**
       - Minimum number of idle processes
         that Unit tries to maintain for an app.
         When the app is started,
-        :samp:`spare` idles are launched;
+        **spare** idles are launched;
         Unit passes new requests to existing idles,
         forking new idles
-        to keep the :samp:`spare` level
-        if :samp:`max` allows.
+        to keep the **spare** level
+        if **max** allows.
         When busy processes complete their work
         and turn idle again,
         Unit terminates extra idles
-        after :samp:`idle_timeout`.
+        after **idle_timeout**.
 
-If :samp:`processes` is omitted entirely,
+If **processes** is omitted entirely,
 Unit creates 1 static process.
-If an empty object is provided: :samp:`"processes": {}`,
+If an empty object is provided: **"processes": {}**,
 dynamic behavior
 with default option values
 is assumed.
@@ -3945,7 +3945,7 @@ modify its source
 to make it Unit-aware
 and rebuild the app.
 
-.. nxt_details:: Updating Go Apps to Run on Unit
+.. nxt_details:: Updating Go apps to run on Unit
    :hash: updating-go-apps
 
    Unit uses
@@ -3953,7 +3953,7 @@ and rebuild the app.
    to invoke C code from Go,
    so check the following prerequisites:
 
-   - The :envvar:`CGO_ENABLED` variable is set to :samp:`1`:
+   - The :envvar:`CGO_ENABLED` variable is set to **1**:
 
      .. code-block:: console
 
@@ -3990,8 +3990,8 @@ and rebuild the app.
 
         # make libunit-install
 
-   In the :samp:`import` section,
-   list the :samp:`unit.nginx.org/go` package:
+   In the **import** section,
+   list the **unit.nginx.org/go** package:
 
    .. code-block:: go
 
@@ -4001,8 +4001,8 @@ and rebuild the app.
           ...
       )
 
-   Replace the :samp:`http.ListenAndServe` call
-   with :samp:`unit.ListenAndServe`:
+   Replace the **http.ListenAndServe** call
+   with **unit.ListenAndServe**:
 
    .. code-block:: go
 
@@ -4042,11 +4042,11 @@ and rebuild the app.
    The resulting executable works as follows:
 
    - When you run it standalone,
-     the :samp:`unit.ListenAndServe` call
-     falls back to :samp:`http` functionality.
+     the **unit.ListenAndServe** call
+     falls back to **http** functionality.
 
    - When Unit runs it,
-     :samp:`unit.ListenAndServe` directly communicates
+     **unit.ListenAndServe** directly communicates
      with Unit's router process,
      ignoring the address supplied as its first argument
      and relying on the
@@ -4064,17 +4064,17 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`executable` (required)
+    * - **executable** (required)
       - String;
         pathname of the application,
-        absolute or relative to :samp:`working_directory`.
+        absolute or relative to **working_directory**.
 
-    * - :samp:`arguments`
+    * - **arguments**
       - Array of strings;
         command-line arguments
         to be passed to the application.
         The example below is equivalent to
-        :samp:`/www/chat/bin/chat_app --tmp-files /tmp/go-cache`.
+        **/www/chat/bin/chat_app --tmp-files /tmp/go-cache**.
 
 Example:
 
@@ -4122,30 +4122,30 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`webapp` (required)
+    * - **webapp** (required)
       - String;
         pathname
-        of the application's :file:`.war` file
+        of the application's **.war** file
         (packaged or unpackaged).
 
-    * - :samp:`classpath`
+    * - **classpath**
       - Array of strings;
         paths to your app's required libraries
         (may point to directories
-        or individual :file:`.jar` files).
+        or individual **.jar** files).
 
-    * - :samp:`options`
+    * - **options**
       - Array of strings;
         defines JVM runtime options.
 
         Unit itself
-        exposes the :samp:`-Dnginx.unit.context.path` option
-        that defaults to :file:`/`;
+        exposes the **-Dnginx.unit.context.path** option
+        that defaults to **/**;
         use it to customize the
         `context path
         <https://javaee.github.io/javaee-spec/javadocs/javax/servlet/ServletContext.html#getContextPath-->`__.
 
-    * - :samp:`thread_stack_size`
+    * - **thread_stack_size**
       - Integer;
         stack size of a worker thread
         (in bytes,
@@ -4155,7 +4155,7 @@ you have:
         The default is usually system dependent
         and can be set with :program:`ulimit -s <SIZE_KB>`.
 
-    * - :samp:`threads`
+    * - **threads**
       - Integer;
         number of worker threads
         per :ref:`app process <sec-processes>`.
@@ -4163,7 +4163,7 @@ you have:
         each app process creates this number of threads
         to handle requests.
 
-        The default is :samp:`1`.
+        The default is **1**.
 
 Example:
 
@@ -4229,12 +4229,12 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`executable` (required)
+    * - **executable** (required)
       - String;
         pathname of the app,
-        absolute or relative to :samp:`working_directory`.
+        absolute or relative to **working_directory**.
 
-        Supply your :file:`.js` pathname here
+        Supply your **.js** pathname here
         and start the file itself
         with a proper shebang:
 
@@ -4248,12 +4248,12 @@ you have:
            the file you list here
            so Unit can start it.
 
-    * - :samp:`arguments`
+    * - **arguments**
       - Array of strings;
         command-line arguments
         to be passed to the app.
         The example below is equivalent to
-        :samp:`/www/apps/node-app/app.js --tmp-files /tmp/node-cache`.
+        **/www/apps/node-app/app.js --tmp-files /tmp/node-cache**.
 
 Example:
 
@@ -4315,20 +4315,20 @@ depending on your version of Node.js:
              ]
          }
 
-The loader overrides the :samp:`http` and :samp:`websocket` modules
+The loader overrides the **http** and **websocket** modules
 with their Unit-aware versions
 and starts the app.
 
 You can also run your Node.js apps without the loader
 by updating the application source code.
-For that, use :samp:`unit-http` instead of :samp:`http` in your code:
+For that, use **unit-http** instead of **http** in your code:
 
 .. code-block:: javascript
 
    var http = require('unit-http');
 
 To use the WebSocket protocol,
-your app only needs to replace the default :samp:`websocket`:
+your app only needs to replace the default **websocket**:
 
 .. code-block:: javascript
 
@@ -4366,11 +4366,11 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`script` (required)
+    * - **script** (required)
       - String;
         PSGI script path.
 
-    * - :samp:`thread_stack_size`
+    * - **thread_stack_size**
       - Integer;
         stack size of a worker thread
         (in bytes,
@@ -4380,7 +4380,7 @@ you have:
         The default is usually system dependent
         and can be set with :program:`ulimit -s <SIZE_KB>`.
 
-    * - :samp:`threads`
+    * - **threads**
       - Integer;
         number of worker threads
         per :ref:`app process <sec-processes>`.
@@ -4388,7 +4388,7 @@ you have:
         each app process creates this number of threads
         to handle requests.
 
-        The default is :samp:`1`.
+        The default is **1**.
 
 Example:
 
@@ -4431,52 +4431,52 @@ Besides the
     * - Option
       - Description
 
-    * - :samp:`root` (required)
+    * - **root** (required)
       - String;
         base directory
         of the app's file structure.
         All URI paths are relative to it.
 
-    * - :samp:`index`
+    * - **index**
       - String;
         filename added to URI paths
         that point to directories
-        if no :samp:`script` is set.
+        if no **script** is set.
 
-        The default is :samp:`index.php`.
+        The default is **index.php**.
 
-    * - :samp:`options`
+    * - **options**
       - Object;
         :ref:`defines <configuration-php-options>`
-        the :file:`php.ini` location and options.
+        the **php.ini** location and options.
 
-    * - :samp:`script`
+    * - **script**
       - String;
-        filename of a :samp:`root`-based PHP script
+        filename of a **root**-based PHP script
         that serves all requests to the app.
 
-    * - :samp:`targets`
+    * - **targets**
       - Object;
         defines application sections with
         :ref:`custom <configuration-php-targets>`
-        :samp:`root`, :samp:`script`, and :samp:`index` values.
+        **root**, **script**, and **index** values.
 
-The :samp:`index` and :samp:`script` options
+The **index** and **script** options
 enable two modes of operation:
 
-- If :samp:`script` is set,
+- If **script** is set,
   all requests to the application are handled
   by the script you specify in this option.
 
 - Otherwise, the requests are served
   according to their URI paths;
   if they point to directories,
-  :samp:`index` is used.
+  **index** is used.
 
 .. _configuration-php-options:
 
-You can customize :file:`php.ini`
-via the :samp:`options` object:
+You can customize **php.ini**
+via the **options** object:
 
 .. list-table::
     :header-rows: 1
@@ -4484,38 +4484,38 @@ via the :samp:`options` object:
     * - Option
       - Description
 
-    * - :samp:`admin`, :samp:`user`
+    * - **admin**, **user**
       - Objects for extra directives.
-        Values in :samp:`admin` are set in :samp:`PHP_INI_SYSTEM` mode,
+        Values in **admin** are set in **PHP_INI_SYSTEM** mode,
         so the app can't alter them;
-        :samp:`user` values are set in :samp:`PHP_INI_USER` mode
+        **user** values are set in **PHP_INI_USER** mode
         and can be
         `updated
         <https://www.php.net/manual/en/function.ini-set.php>`__
         at runtime.
 
         - The objects override the settings
-          from any :file:`*.ini` files
+          from any ***.ini** files
 
-        - The :samp:`admin` object can only set what's
+        - The **admin** object can only set what's
           `listed <https://www.php.net/manual/en/ini.list.php>`__
-          as :samp:`PHP_INI_SYSTEM`;
+          as **PHP_INI_SYSTEM**;
           for other modes,
-          set :samp:`user`
+          set **user**
 
-        - Neither :samp:`admin` nor :samp:`user`
+        - Neither **admin** nor **user**
           can set directives listed as
           `php.ini only <https://www.php.net/manual/en/ini.list.php>`__
-          except for :samp:`disable_classes` and :samp:`disable_functions`
+          except for **disable_classes** and **disable_functions**
 
-    * - :samp:`file`
+    * - **file**
       - String;
-        pathname of the :file:`php.ini` file with
+        pathname of the **php.ini** file with
         `PHP configuration directives
         <https://www.php.net/manual/en/ini.list.php>`__.
 
-To load multiple :file:`.ini` files,
-use :samp:`environment` with :envvar:`PHP_INI_SCAN_DIR` to
+To load multiple **.ini** files,
+use **environment** with :envvar:`PHP_INI_SCAN_DIR` to
 `scan a custom directory
 <https://www.php.net/manual/en/configuration.file.php>`__:
 
@@ -4537,18 +4537,18 @@ use :samp:`environment` with :envvar:`PHP_INI_SCAN_DIR` to
 Mind that the colon that prefixes the value here is a path separator;
 it causes PHP to scan the directory preconfigured with the
 :option:`!--with-config-file-scan-dir` option,
-which is usually :file:`/etc/php.d/`,
-and then the directory you set here, which is :file:`/tmp/php.inis/`.
-To skip the preconfigured directory, drop the :samp:`:` prefix.
+which is usually **/etc/php.d/**,
+and then the directory you set here, which is **/tmp/php.inis/**.
+To skip the preconfigured directory, drop the **:** prefix.
 
 .. note::
 
-   Values in :samp:`options` must be strings
-   (for example, :samp:`"max_file_uploads": "4"`,
-   not :samp:`"max_file_uploads": 4`);
+   Values in **options** must be strings
+   (for example, **"max_file_uploads": "4"**,
+   not **"max_file_uploads": 4**);
    for boolean flags,
-   use :samp:`"0"` and :samp:`"1"` only.
-   For details aof :samp:`PHP_INI_*` modes,
+   use **"0"** and **"1"** only.
+   For details aof **PHP_INI_*** modes,
    see the
    `PHP docs
    <https://www.php.net/manual/en/configuration.changes.modes.php>`__.
@@ -4556,7 +4556,7 @@ To skip the preconfigured directory, drop the :samp:`:` prefix.
 
 .. note::
 
-   Unit implements the :samp:`fastcgi_finish_request()` `function
+   Unit implements the **fastcgi_finish_request()** `function
    <https://www.php.net/manual/en/function.fastcgi-finish-request.php>`_ in a
    manner similar to PHP-FPM.
 
@@ -4613,10 +4613,10 @@ for a single PHP app:
    }
 
 Each target is an object
-that specifies :samp:`root`
-and can define :samp:`index` or :samp:`script`
+that specifies **root**
+and can define **index** or **script**
 just like a regular app does.
-Targets can be used by the :samp:`pass` options
+Targets can be used by the **pass** options
 in listeners and routes
 to serve requests:
 
@@ -4647,13 +4647,13 @@ to serve requests:
    }
 
 App-wide settings
-(:samp:`isolation`, :samp:`limits`, :samp:`options`, :samp:`processes`)
+(**isolation**, **limits**, **options**, **processes**)
 are shared by all targets within the app.
 
 .. warning::
 
-   If you specify :samp:`targets`,
-   there should be no :samp:`root`, :samp:`index`, or :samp:`script`
+   If you specify **targets**,
+   there should be no **root**, **index**, or **script**
    defined at the app level.
 
 .. note::
@@ -4700,7 +4700,7 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`module` (required)
+    * - **module** (required)
       - String;
         app's module name.
         This module is
@@ -4708,24 +4708,24 @@ you have:
         by Unit
         the usual Python way.
 
-    * - :samp:`callable`
+    * - **callable**
       - String;
-        name of the :samp:`module`-based callable
+        name of the **module**-based callable
         that Unit runs as the app.
 
-        The default is :samp:`application`.
+        The default is **application**.
 
-    * - :samp:`home`
+    * - **home**
       - String;
         path to the app's
         `virtual environment
         <https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments>`__.
-        Absolute or relative to :samp:`working_directory`.
+        Absolute or relative to **working_directory**.
 
         .. note::
 
            The Python version used to run the app
-           is determined by :samp:`type`;
+           is determined by **type**;
            for performance,
            Unit doesn't use the command-line interpreter
            from the virtual environment.
@@ -4735,13 +4735,13 @@ you have:
 
            Seeing this in Unit's
            :ref:`log <troubleshooting-log>`
-           after you set up :samp:`home` for your app?
+           after you set up **home** for your app?
            This usually occurs
            if the interpreter can't use the virtual environment,
            possible reasons including:
 
            - Version mismatch
-             between the :samp:`type` setting
+             between the **type** setting
              and the virtual environment;
              check the environment's version:
 
@@ -4751,7 +4751,7 @@ you have:
                 (venv) $ python --version
 
            - Unit's unprivileged user
-             (usually :samp:`unit`)
+             (usually **unit**)
              having no access to the environment's files;
              assign the necessary rights:
 
@@ -4759,30 +4759,30 @@ you have:
 
                 # chown -R :nxt_hint:`unit:unit <User and group that Unit's router runs as by default>` :nxt_ph:`/path/to/venv/ <Path to the virtual environment; use a real path in your commands>`
 
-    * - :samp:`path`
+    * - **path**
       - String or an array of strings;
         additional Python module lookup paths.
-        These values are prepended to :samp:`sys.path`.
+        These values are prepended to **sys.path**.
 
-    * - :samp:`prefix`
+    * - **prefix**
       - String;
-        :samp:`SCRIPT_NAME` context value for WSGI
-        or the :samp:`root_path` context value for ASGI.
+        **SCRIPT_NAME** context value for WSGI
+        or the **root_path** context value for ASGI.
         Should start with a slash
-        (:samp:`/`).
+        (**/**).
 
-    * - :samp:`protocol`
+    * - **protocol**
       - String;
         hints Unit that the app uses a certain interface.
-        Can be :samp:`asgi` or :samp:`wsgi`.
+        Can be **asgi** or **wsgi**.
 
-    * - :samp:`targets`
+    * - **targets**
       - Object;
         app sections with
         :ref:`custom <configuration-python-targets>`
-        :samp:`module` and :samp:`callable` values.
+        **module** and **callable** values.
 
-    * - :samp:`thread_stack_size`
+    * - **thread_stack_size**
       - Integer;
         stack size of a worker thread
         (in bytes,
@@ -4792,7 +4792,7 @@ you have:
         The default is usually system dependent
         and can be set with :program:`ulimit -s <SIZE_KB>`.
 
-    * - :samp:`threads`
+    * - **threads**
       - Integer;
         number of worker threads
         per :ref:`app process <sec-processes>`.
@@ -4800,7 +4800,7 @@ you have:
         each app process creates this number of threads
         to handle requests.
 
-        The default is :samp:`1`.
+        The default is **1**.
 
 Example:
 
@@ -4819,15 +4819,15 @@ Example:
        "group": "www"
    }
 
-This snippet runs the :samp:`app` callable
-from the :file:`/www/store/cart/run.py` module
-with :file:`/www/store/cart/` as the working directory
-and :file:`/www/store/.virtualenv/` as the virtual environment;
-the :samp:`path` value
+This snippet runs the **app** callable
+from the **/www/store/cart/run.py** module
+with **/www/store/cart/** as the working directory
+and **/www/store/.virtualenv/** as the virtual environment;
+the **path** value
 accommodates for situations
 when some modules of the app
 are imported
-from outside the :file:`cart/` subdirectory.
+from outside the **cart/** subdirectory.
 
 .. _configuration-python-asgi:
 
@@ -4872,15 +4872,15 @@ uses
 Choose either one according to your needs;
 Unit tries to infer your choice automatically.
 If this inference fails,
-use the :samp:`protocol` option
+use the **protocol** option
 to set the interface explicitly.
 
 .. note::
 
-   The :samp:`prefix` option
-   controls the :samp:`SCRIPT_NAME`
+   The **prefix** option
+   controls the **SCRIPT_NAME**
    (`WSGI <https://wsgi.readthedocs.io/en/latest/definitions.html>`__)
-   or :samp:`root_path`
+   or **root_path**
    (`ASGI
    <https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope>`__)
    setting in Python's context,
@@ -4918,10 +4918,10 @@ for a single Python app:
    }
 
 Each target is an object
-that specifies :samp:`module`
-and can also define :samp:`callable` and :samp:`prefix`
+that specifies **module**
+and can also define **callable** and **prefix**
 just like a regular app does.
-Targets can be used by the :samp:`pass` options
+Targets can be used by the **pass** options
 in listeners and routes
 to serve requests:
 
@@ -4951,14 +4951,14 @@ to serve requests:
        ]
    }
 
-The :samp:`home`, :samp:`path`, :samp:`protocol`, :samp:`threads`, and
-:samp:`thread_stack_size` settings
+The **home**, **path**, **protocol**, **threads**, and
+**thread_stack_size** settings
 are shared by all targets in the app.
 
 .. warning::
 
-   If you specify :samp:`targets`,
-   there should be no :samp:`module` or :samp:`callable`
+   If you specify **targets**,
+   there should be no **module** or **callable**
    defined at the app level.
    Moreover, you can't combine WSGI and ASGI targets
    within a single app.
@@ -5023,20 +5023,20 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`script` (required)
+    * - **script** (required)
       - String;
         rack script pathname,
-        including the :file:`.ru` extension,
+        including the **.ru** extension,
         for instance:
-        :file:`/www/rubyapp/script.ru`.
+        **/www/rubyapp/script.ru**.
 
-    * - :samp:`hooks`
+    * - **hooks**
       - String;
-        pathname of the :file:`.rb` file
+        pathname of the **.rb** file
         setting the event hooks
         invoked during the app's lifecycle.
 
-    * - :samp:`threads`
+    * - **threads**
       - Integer;
         number of worker threads
         per :ref:`app process <sec-processes>`.
@@ -5044,7 +5044,7 @@ you have:
         each app process creates this number of threads
         to handle requests.
 
-        The default is :samp:`1`.
+        The default is **1**.
 
 Example:
 
@@ -5059,13 +5059,13 @@ Example:
        "hooks": "hooks.rb"
    }
 
-The :samp:`hooks` script
+The **hooks** script
 is evaluated when the app starts.
 If set, it can define blocks of Ruby code named
-:samp:`on_worker_boot`,
-:samp:`on_worker_shutdown`,
-:samp:`on_thread_boot`,
-or :samp:`on_thread_shutdown`.
+**on_worker_boot**,
+**on_worker_shutdown**,
+**on_thread_boot**,
+or **on_thread_shutdown**.
 If provided,
 these blocks are called
 at the respective points
@@ -5141,14 +5141,14 @@ you have:
     * - Option
       - Description
 
-    * - :samp:`module` (required)
+    * - **module** (required)
       - String;
         WebAssembly module pathname,
-        including the :file:`.wasm` extension,
+        including the **.wasm** extension,
         for instance:
-        :file:`/www/wasmapp/module.wasm`.
+        **/www/wasmapp/module.wasm**.
 
-    * - :samp:`request_handler` (required)
+    * - **request_handler** (required)
       - String;
         name of the request handler function.
         If you use Unit with the official :program:`unit-wasm`
@@ -5163,7 +5163,7 @@ you have:
         of the shared memory block
         used to pass data in and out the app.
 
-    * - :samp:`malloc_handler` (required)
+    * - **malloc_handler** (required)
       - String;
         name of the memory allocator function.
         If you use Unit with the official :program:`unit-wasm`
@@ -5177,7 +5177,7 @@ you have:
         to allocate the shared memory block
         used to pass data in and out the app.
 
-    * - :samp:`free_handler` (required)
+    * - **free_handler** (required)
       - String;
         name of the memory deallocator function.
         If you use Unit with the official :program:`unit-wasm`
@@ -5191,9 +5191,9 @@ you have:
         to free the shared memory block
         used to pass data in and out the app.
 
-    * - :samp:`access`
+    * - **access**
       - Object;
-        its only array member, :samp:`filesystem`, lists directories
+        its only array member, **filesystem**, lists directories
         to which the application has access:
 
         .. code-block:: json
@@ -5205,7 +5205,7 @@ you have:
                ]
            }
 
-    * - :samp:`module_init_handler`,
+    * - **module_init_handler**,
 
       - String;
         name of the module initilization function.
@@ -5220,7 +5220,7 @@ you have:
         at language module startup,
         after the WebAssembly module was initialised.
 
-    * - :samp:`module_end_handler`
+    * - **module_end_handler**
 
       - String;
         name of the module finalization function.
@@ -5234,7 +5234,7 @@ you have:
         It is invoked by the WebAssembly language module
         at language module shutdown.
 
-    * - :samp:`request_init_handler`
+    * - **request_init_handler**
 
       - String;
         name of the request initialization function.
@@ -5248,7 +5248,7 @@ you have:
         It is invoked by the WebAssembly language module
         at the start of each request.
 
-    * - :samp:`request_end_handler`
+    * - **request_end_handler**
 
       - String;
         name of the request finalization function.
@@ -5263,7 +5263,7 @@ you have:
         at the end of each request,
         when the headers and the request body were received.
 
-    * - :samp:`response_end_handler`
+    * - **response_end_handler**
 
       - String;
         name of the response finalization function.
@@ -5323,7 +5323,7 @@ source code and documentation.
 Settings
 ********
 
-Unit has a global :samp:`settings` configuration object
+Unit has a global **settings** configuration object
 that stores instance-wide preferences.
 
 .. list-table::
@@ -5332,12 +5332,12 @@ that stores instance-wide preferences.
     * - Option
       - Description
 
-    * - :samp:`http`
+    * - **http**
       - Object;
         fine-tunes handling of HTTP requests
         from the clients.
 
-    * - :samp:`js_module`
+    * - **js_module**
       - String or an array of strings;
         lists enabled
         :program:`njs`
@@ -5345,7 +5345,7 @@ that stores instance-wide preferences.
         uploaded
         via the :doc:`control API <controlapi>`.
 
-In turn, the :samp:`http` option exposes the following settings:
+In turn, the **http** option exposes the following settings:
 
 .. list-table::
     :header-rows: 1
@@ -5353,7 +5353,7 @@ In turn, the :samp:`http` option exposes the following settings:
     * - Option
       - Description
 
-    * - :samp:`body_read_timeout`
+    * - **body_read_timeout**
       - Maximum number of seconds
         to read data from the body
         of a client's request.
@@ -5367,10 +5367,10 @@ In turn, the :samp:`http` option exposes the following settings:
 
         The default is 30.
 
-    * - :samp:`discard_unsafe_fields`
+    * - **discard_unsafe_fields**
       - Boolean;
         controls header field name parsing.
-        If it's set to :samp:`true`,
+        If it's set to **true**,
         Unit only processes header names
         made of alphanumeric characters and hyphens
         (see
@@ -5378,11 +5378,11 @@ In turn, the :samp:`http` option exposes the following settings:
         <https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.1-6.2>`__);
         otherwise,
         these characters are also permitted:
-        :samp:`.!#$%&'*+^_\`|~`.
+        **.!#$%&'*+^_`|~**.
 
-        The default is :samp:`true`.
+        The default is **true**.
 
-    * - :samp:`header_read_timeout`
+    * - **header_read_timeout**
       - Maximum number of seconds
         to read the header
         of a client's request.
@@ -5393,7 +5393,7 @@ In turn, the :samp:`http` option exposes the following settings:
 
         The default is 30.
 
-    * - :samp:`idle_timeout`
+    * - **idle_timeout**
       - Maximum number of seconds
         between requests
         in a keep-alive connection.
@@ -5404,14 +5404,14 @@ In turn, the :samp:`http` option exposes the following settings:
 
         The default is 180.
 
-    * - :samp:`log_route`
+    * - **log_route**
       - Boolean;
         enables or disables
         :ref:`router logging <troubleshooting-router-log>`.
 
-        The default is :samp:`false` (disabled).
+        The default is **false** (disabled).
 
-    * - :samp:`max_body_size`
+    * - **max_body_size**
       - Maximum number of bytes
         in the body of a client's request.
         If the body size exceeds this value,
@@ -5420,7 +5420,7 @@ In turn, the :samp:`http` option exposes the following settings:
 
         The default is 8388608 (8 MB).
 
-    * - :samp:`send_timeout`
+    * - **send_timeout**
       - Maximum number of seconds
         to transmit data
         as a response to the client.
@@ -5434,20 +5434,20 @@ In turn, the :samp:`http` option exposes the following settings:
 
         The default is 30.
 
-    * - :samp:`server_version`
+    * - **server_version**
       - Boolean;
-        if set to :samp:`false`,
+        if set to **false**,
         Unit omits version information
-        in its :samp:`Server` response
+        in its **Server** response
         `header fields
         <https://datatracker.ietf.org/doc/html/rfc9110.html#section-10.2.4>`__.
 
-        The default is :samp:`true`.
+        The default is **true**.
 
-    * - :samp:`static`
+    * - **static**
       - Object;
         configures static asset handling.
-        Has a single object option named :samp:`mime_types`
+        Has a single object option named **mime_types**
         that defines specific
         `MIME types
         <https://www.iana.org/assignments/media-types/media-types.xhtml>`__
@@ -5471,32 +5471,32 @@ In turn, the :samp:`http` option exposes the following settings:
         .. _configuration-mime:
 
         Defaults:
-        :file:`.aac`, :file:`.apng`, :file:`.atom`,
-        :file:`.avi`, :file:`.avif`, :file:`avifs`, :file:`.bin`, :file:`.css`,
-        :file:`.deb`, :file:`.dll`, :file:`.exe`, :file:`.flac`, :file:`.gif`,
-        :file:`.htm`, :file:`.html`, :file:`.ico`, :file:`.img`, :file:`.iso`,
-        :file:`.jpeg`, :file:`.jpg`, :file:`.js`, :file:`.json`, :file:`.md`,
-        :file:`.mid`, :file:`.midi`, :file:`.mp3`, :file:`.mp4`, :file:`.mpeg`,
-        :file:`.mpg`, :file:`.msi`, :file:`.ogg`, :file:`.otf`, :file:`.pdf`,
-        :file:`.php`, :file:`.png`, :file:`.rpm`, :file:`.rss`, :file:`.rst`,
-        :file:`.svg`, :file:`.ttf`, :file:`.txt`, :file:`.wav`, :file:`.webm`,
-        :file:`.webp`, :file:`.woff2`, :file:`.woff`, :file:`.xml`, and
-        :file:`.zip`.
+        **.aac**, **.apng**, **.atom**,
+        **.avi**, **.avif**, **avifs**, **.bin**, **.css**,
+        **.deb**, **.dll**, **.exe**, **.flac**, **.gif**,
+        **.htm**, **.html**, **.ico**, **.img**, **.iso**,
+        **.jpeg**, **.jpg**, **.js**, **.json**, **.md**,
+        **.mid**, **.midi**, **.mp3**, **.mp4**, **.mpeg**,
+        **.mpg**, **.msi**, **.ogg**, **.otf**, **.pdf**,
+        **.php**, **.png**, **.rpm**, **.rss**, **.rst**,
+        **.svg**, **.ttf**, **.txt**, **.wav**, **.webm**,
+        **.webp**, **.woff2**, **.woff**, **.xml**, and
+        **.zip**.
 
 .. _configuration-access-log:
 
 **********
-Access Log
+Access log
 **********
 
 To enable basic access logging,
 specify the log file path
-in the :samp:`access_log` option
-of the :samp:`config` object.
+in the **access_log** option
+of the **config** object.
 
 In the example below,
 all requests will be logged
-to :file:`/var/log/access.log`:
+to **/var/log/access.log**:
 
 .. code-block:: console
 
@@ -5518,10 +5518,10 @@ Example of a CLF line:
    127.0.0.1 - - [21/Oct/2015:16:29:00 -0700] "GET / HTTP/1.1" 200 6022 "http://example.com/links.html" "Godzilla/5.0 (X11; Minix i286) Firefox/42"
 
 =====================
-Custom Log Formatting
+Custom log formatting
 =====================
 
-The :samp:`access_log` option
+The **access_log** option
 can be also set to an object
 to customize both the log path
 and its format:
@@ -5532,7 +5532,7 @@ and its format:
     * - Option
       - Description
 
-    * - :samp:`format`
+    * - **format**
       - String;
         sets the log format.
         Besides arbitrary text,
@@ -5540,7 +5540,7 @@ and its format:
         :ref:`variables <configuration-variables>`
         Unit supports.
 
-    * - :samp:`path`
+    * - **path**
       - String;
         pathname of the access log file.
 
@@ -5556,7 +5556,7 @@ Example:
    }
 
 By a neat coincidence,
-the above :samp:`format`
+the above **format**
 is the default setting.
 Also, mind that the log entry
 is formed *after* the request has been handled.

--- a/source/controlapi.rst
+++ b/source/controlapi.rst
@@ -13,7 +13,7 @@ Unit's configuration is JSON-based,
 accessible via a RESTful control API,
 and entirely manageable over HTTP.
 The control API provides a root object
-(:samp:`/`)
+(**/**)
 that comprises four primary options:
 
 .. list-table::
@@ -22,19 +22,19 @@ that comprises four primary options:
    * - Object
      - Description
 
-   * - :samp:`/certificates`
+   * - **/certificates**
      - Responsible for SSL/TLS
        :doc:`certificate management <certificates>`.
 
-   * - :samp:`/config`
+   * - **/config**
      - Used for general
        :doc:`configuration management <configuration>`.
 
-   * - :samp:`/control`
+   * - **/control**
      - Queried for
        :ref:`application restart <configuration-proc-mgmt>`.
 
-   * - :samp:`/status`
+   * - **/status**
      - Queried for
        :doc:`usage statistics <usagestats>`.
 
@@ -51,7 +51,7 @@ For consistency and
 our examples use Unix domain sockets
 unless stated otherwise.
 Example queries use :program:`curl`,
-and URIs are prefixed with :samp:`http://localhost`
+and URIs are prefixed with **http://localhost**
 as the utility expects
 (the hostname is irrelevant for Unit itself),
 but you can use any HTTP tool you like.
@@ -60,7 +60,7 @@ may benefit from this
 `third-party extension
 <https://marketplace.visualstudio.com/items?itemName=Stanislav.vscode-nginx-unit>`__.
 
-.. nxt_details:: (Lack of) Configuration Files
+.. nxt_details:: No configuration files used
    :hash: no-config-files
 
    The control API is the single source of truth
@@ -90,7 +90,7 @@ may benefit from this
      With the control API,
      the entire configuration is a single, organized, and navigatable entity.
 
-.. nxt_details:: Replicating Unit States
+.. nxt_details:: Replicating Unit states
    :hash: conf-replication
 
    Although Unit is fully dynamic,
@@ -154,7 +154,7 @@ may benefit from this
       # systemctl restart unit
 
    If you run your Unit instances manually,
-   :option:`!--state` can be used to set the state directory at
+   **--state** can be used to set the state directory at
    :ref:`startup <source-startup>`.
 
    After restart,
@@ -165,7 +165,7 @@ may benefit from this
 .. _controlapi-openapi:
 
 *********************
-OpenAPI Specification
+OpenAPI specification
 *********************
 
    For a more formal approach
@@ -183,7 +183,7 @@ OpenAPI Specification
       $ docker build --tag=unit-openapi -f unit-openapi.Dockerfile .
       $ docker run -d -p 8765:8765 -p 8080:8080 unit-openapi
 
-   Next, open :samp:`http://localhost:8765` in a browser.
+   Next, open **http://localhost:8765** in a browser.
 
    To use this image against a pre-existing Unit instance,
    type in the address and port of the instance's
@@ -199,12 +199,12 @@ OpenAPI Specification
 .. _configuration-quickstart:
 
 ***********
-Quick Start
+Quick start
 ***********
 
 For a brief intro,
 we configure Unit to serve a static file.
-Suppose you saved this as :file:`/www/data/index.html`:
+Suppose you saved this as **/www/data/index.html**:
 
 .. code-block:: html
 
@@ -236,7 +236,7 @@ Now, Unit should
 :ref:`listen <configuration-listeners>`
 on a port that
 :ref:`routes <configuration-routes>`
-the incoming requests to a :samp:`share` action,
+the incoming requests to a **share** action,
 which serves the file:
 
 .. code-block:: json
@@ -258,10 +258,10 @@ which serves the file:
    }
 
 To configure Unit,
-:samp:`PUT` this snippet to the :samp:`/config` section via the
+**PUT** this snippet to the **/config** section via the
 :ref:`control socket <source-startup>`.
 Working with JSON in the command line can be cumbersome;
-instead, save and upload it as :file:`snippet.json`:
+instead, save and upload it as **snippet.json**:
 
 .. code-block:: console
 
@@ -274,8 +274,8 @@ instead, save and upload it as :file:`snippet.json`:
 
 To confirm this works,
 query the listener.
-Unit responds with the :file:`index.html` file
-from the :samp:`share` directory:
+Unit responds with the **index.html** file
+from the **share** directory:
 
 .. code-block:: console
 
@@ -295,7 +295,7 @@ from the :samp:`share` directory:
 .. _configuration-mgmt:
 
 ****************
-API Manipulation
+API manipulation
 ****************
 
 To address parts of the control API,
@@ -323,21 +323,21 @@ The API supports the following HTTP methods:
    * - Method
      - Action
 
-   * - :samp:`GET`
+   * - **GET**
      - Returns the entity at the request URI
        as a JSON value in the HTTP response body.
 
-   * - :samp:`POST`
+   * - **POST**
      - Updates the *array* at the request URI,
        appending the JSON value
        from the HTTP request body.
 
-   * - :samp:`PUT`
+   * - **PUT**
      - Replaces the entity at the request URI
        and returns a status message
        in the HTTP response body.
 
-   * - :samp:`DELETE`
+   * - **DELETE**
      - Deletes the entity at the request URI
        and returns a status message
        in the HTTP response body.
@@ -371,7 +371,7 @@ provided you supply the right JSON:
 
 However, the first command replaces the *entire* listener,
 dropping any other options you could have configured,
-whereas the second one replaces only the :samp:`pass` value
+whereas the second one replaces only the **pass** value
 and leaves other options intact.
 
 .. _conf-examples:
@@ -383,7 +383,7 @@ Examples
 To minimize typos and effort,
 avoid embedding JSON payload in your commands;
 instead, store your configuration snippets for review and reuse.
-For instance, save your application object as :file:`wiki.json`:
+For instance, save your application object as **wiki.json**:
 
 .. code-block:: json
 
@@ -395,7 +395,7 @@ For instance, save your application object as :file:`wiki.json`:
        "path": "/www/wiki/"
    }
 
-Use it to set up an application called :samp:`wiki-prod`:
+Use it to set up an application called **wiki-prod**:
 
 .. code-block:: console
 
@@ -403,14 +403,14 @@ Use it to set up an application called :samp:`wiki-prod`:
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` http://localhost/config/applications/wiki-prod
 
 Use it again to set up a development version of the same app
-called :samp:`wiki-dev`:
+called **wiki-dev**:
 
 .. code-block:: console
 
    # curl -X PUT --data-binary @wiki.json \
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` http://localhost/config/applications/wiki-dev
 
-Toggle the :samp:`wiki-dev` app to another source code directory:
+Toggle the **wiki-dev** app to another source code directory:
 
 .. code-block:: console
 
@@ -425,7 +425,7 @@ to warm it up a bit:
    # curl -X PUT -d '5' \
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` http://localhost/config/applications/wiki-prod/processes
 
-Add a listener for the :samp:`wiki-prod` app
+Add a listener for the **wiki-prod** app
 to accept requests at all host IPs:
 
 .. code-block:: console
@@ -433,7 +433,7 @@ to accept requests at all host IPs:
    # curl -X PUT -d '{ "pass": "applications/wiki-prod" }' \
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` 'http://localhost/config/listeners/*:8400'
 
-Plug the :samp:`wiki-dev` app into the listener to test it:
+Plug the **wiki-dev** app into the listener to test it:
 
 .. code-block:: console
 
@@ -466,8 +466,8 @@ adding a URI-based route to the development version of the app:
    # curl -X PUT -d '"routes"' --unix-socket \
           :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` 'http://localhost/config/listeners/*:8400/pass'
 
-Next, change the :samp:`wiki-dev`'s URI prefix
-in the :samp:`routes` array,
+Next, change the **wiki-dev**'s URI prefix
+in the **routes** array,
 using its index (0):
 
 .. code-block:: console
@@ -476,7 +476,7 @@ using its index (0):
           http://localhost/config/routes/0/match/uri
 
 Append a route to the prod app:
-:samp:`POST` always adds to the array end,
+**POST** always adds to the array end,
 so there's no need for an index:
 
 .. code-block:: console
@@ -486,7 +486,7 @@ so there's no need for an index:
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>`        \
           http://localhost/config/routes/
 
-Otherwise, use :samp:`PUT` with the array's last index
+Otherwise, use **PUT** with the array's last index
 (0 in our sample)
 *plus one*
 to add the new item at the end:
@@ -498,7 +498,7 @@ to add the new item at the end:
           --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>`       \
           http://localhost/config/routes/1/
 
-To get the complete :samp:`/config` section:
+To get the complete **/config** section:
 
 .. code-block:: console
 
@@ -548,7 +548,7 @@ To get the complete :samp:`/config` section:
            ]
        }
 
-To obtain the :samp:`wiki-dev` application object:
+To obtain the **wiki-dev** application object:
 
 .. code-block:: console
 
@@ -564,14 +564,14 @@ To obtain the :samp:`wiki-dev` application object:
        }
 
 You can save JSON returned by such requests
-as :file:`.json` files for update or review:
+as **.json** files for update or review:
 
 .. code-block:: console
 
    # curl --unix-socket :nxt_ph:`/path/to/control.unit.sock <Path to Unit's control socket in your installation>` \
           http://localhost/config/ > config.json
 
-To drop the listener on :samp:`\*:8400`:
+To drop the listener on **\*:8400**:
 
 .. code-block:: console
 

--- a/source/howto/apollo.rst
+++ b/source/howto/apollo.rst
@@ -9,8 +9,8 @@ To run the `Apollo <https://www.apollographql.com>`_ GraphQL server
 using Unit:
 
 #. Install :ref:`Unit <installation-precomp-pkgs>` with the
-   :samp:`unit-dev/unit-devel` package.  Next, :ref:`install
-   <installation-nodejs-package>` Unit's :samp:`unit-http` package:
+   **unit-dev/unit-devel** package.  Next, :ref:`install
+   <installation-nodejs-package>` Unit's **unit-http** package:
 
    .. code-block:: console
 
@@ -18,7 +18,7 @@ using Unit:
 
 #. Create your app directory, `install
    <https://expressjs.com/en/starter/installing.html>`_ |app|, and link
-   :samp:`unit-http`:
+   **unit-http**:
 
    .. code-block:: console
 
@@ -29,7 +29,7 @@ using Unit:
 
 #. Create the `middleware
    <https://www.apollographql.com/docs/apollo-server/api/express-middleware/>`_
-   module; let's store it as :file:`/path/to/app/apollo.js`.
+   module; let's store it as **/path/to/app/apollo.js**.
    First, initialize the directory:
 
    .. code-block:: console
@@ -97,8 +97,8 @@ using Unit:
       // Modified server startup; port number is overridden by Unit config
       await new Promise((resolve) => httpServer.listen({ port: 80 }, resolve));
 
-   Make sure your :file:`package.json` resembles this
-   (mind :samp:`"type": "module"`):
+   Make sure your **package.json** resembles this
+   (mind **"type": "module"**):
 
    .. code-block:: json
 

--- a/source/howto/bottle.rst
+++ b/source/howto/bottle.rst
@@ -31,14 +31,14 @@ framework using Unit:
    .. warning::
 
       Create your virtual environment with a Python version that matches the
-      language module from Step |_| 1 up to the minor number (:samp:`X.Y` in
-      this example).  Also, the app :samp:`type` in Step |_| 5 must
+      language module from Step |_| 1 up to the minor number (**X.Y** in
+      this example).  Also, the app **type** in Step |_| 5 must
       :ref:`resolve <configuration-apps-common>` to a similarly matching
       version; Unit doesn't infer it from the environment.
 
 #. Let's try an updated version of the `quickstart app
    <https://bottlepy.org/docs/dev/tutorial.html#the-default-application>`_,
-   saving it as :file:`/path/to/app/wsgi.py`:
+   saving it as **/path/to/app/wsgi.py**:
 
    .. code-block:: python
 
@@ -57,7 +57,7 @@ framework using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/bugzilla.rst
+++ b/source/howto/bugzilla.rst
@@ -26,9 +26,9 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-perl>` the |app| configuration for
-   Unit.  The default :file:`.htaccess` scheme roughly translates into the
-   following (use real values for :samp:`share`, :samp:`script`,
-   and :samp:`working_directory`):
+   Unit.  The default **.htaccess** scheme roughly translates into the
+   following (use real values for **share**, **script**,
+   and **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/cakephp.rst
+++ b/source/howto/cakephp.rst
@@ -19,15 +19,15 @@ To run apps based on the `CakePHP <https://cakephp.org>`_ framework using Unit:
       $ cd :nxt_ph:`/path/to/ <Path where the application directory will be created; use a real path in your configuration>`
       $ composer create-project --prefer-dist cakephp/app:4.* :nxt_ph:`app <Arbitrary app name; becomes the application directory name>`
 
-   This creates the app's directory tree at :file:`/path/to/app/`.  Its
-   :file:`webroot/` subdirectory contains both the root :file:`index.php` and
-   the static files; if your app requires additional :file:`.php` scripts, also
+   This creates the app's directory tree at **/path/to/app/**.  Its
+   **webroot/** subdirectory contains both the root **index.php** and
+   the static files; if your app requires additional **.php** scripts, also
    store them here.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, prepare the app :ref:`configuration <configuration-php>` for Unit (use
-   real values for :samp:`share` and :samp:`root`):
+   real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -80,13 +80,13 @@ To run apps based on the `CakePHP <https://cakephp.org>`_ framework using Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the URI omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit runs
+      - The **index** target specifies the **script** that Unit runs
         for *any* URIs the target receives.
 
    For a detailed discussion, see `Fire It Up

--- a/source/howto/catalyst.rst
+++ b/source/howto/catalyst.rst
@@ -16,7 +16,7 @@ To run apps based on the `Catalyst
 
 #. `Create
    <https://metacpan.org/dist/Catalyst-Manual/view/lib/Catalyst/Manual/Tutorial/02_CatalystBasics.pod#CREATE-A-CATALYST-PROJECT>`_
-   a Catalyst app.  Here, let's store it at :file:`/path/to/app/`:
+   a Catalyst app.  Here, let's store it at **/path/to/app/**:
 
    .. code-block:: console
 
@@ -25,7 +25,7 @@ To run apps based on the `Catalyst
       $ cd app
       $ perl Makefile.PL
 
-   Make sure the app's :file:`.psgi` file includes the :file:`lib/`
+   Make sure the app's **.psgi** file includes the **lib/**
    directory:
 
    .. code-block:: perl
@@ -36,7 +36,7 @@ To run apps based on the `Catalyst
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-perl>` the |app| configuration for Unit
-   (use real values for :samp:`script` and :samp:`working_directory`):
+   (use real values for **script** and **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/certbot.rst
+++ b/source/howto/certbot.rst
@@ -53,10 +53,10 @@ Generating Certificates
           }
       }
 
-   Make sure the :samp:`share` directory is accessible for Unit's :ref:`router
-   process <security-apps>` user account, usually :samp:`unit:unit`.
+   Make sure the **share** directory is accessible for Unit's :ref:`router
+   process <security-apps>` user account, usually **unit:unit**.
 
-   Next, run :program:`certbot`, supplying the :samp:`share` directory as the
+   Next, run :program:`certbot`, supplying the **share** directory as the
    webroot path:
 
    .. code-block:: console
@@ -73,7 +73,7 @@ Generating Certificates
    Certbot will provide instructions on updating the DNS entries to prove
    domain ownership.
 
-   Any such :program:`certbot` command stores the resulting :file:`.pem` files
+   Any such :program:`certbot` command stores the resulting **.pem** files
    as follows:
 
    .. code-block:: none
@@ -93,7 +93,7 @@ Generating Certificates
       as well, but they're omitted here for brevity.
 
 #. Create a certificate bundle fit for Unit and upload it to the
-   :samp:`certificates` section of Unit's :ref:`control API
+   **certificates** section of Unit's :ref:`control API
    <configuration-api>`:
 
    .. code-block:: console
@@ -182,8 +182,8 @@ For manual renewal and rollover:
              }
 
    Now you have two certificate bundles uploaded; Unit knows them as
-   :samp:`certbot1` and :samp:`certbot2`.  Optionally, query the
-   :samp:`certificates` section to review common details such as expiry dates,
+   **certbot1** and **certbot2**.  Optionally, query the
+   **certificates** section to review common details such as expiry dates,
    subjects, or issuers:
 
    .. code-block:: console
@@ -220,8 +220,8 @@ For manual renewal and rollover:
    by configuring several certificate bundles for a listener.
 
    Suppose you've successfully used Certbot to obtain Let's Encrypt
-   certificates for two domains, :samp:`www.example.com` and
-   :samp:`cdn.example.com`.  First, upload them to Unit using the same steps as
+   certificates for two domains, **www.example.com** and
+   **cdn.example.com**.  First, upload them to Unit using the same steps as
    earlier:
 
    .. code-block:: console
@@ -250,7 +250,7 @@ For manual renewal and rollover:
              }
 
    Next, configure the listener, supplying both bundles as an array value for
-   the :samp:`tls/certificate` option:
+   the **tls/certificate** option:
 
    .. code-block:: console
 

--- a/source/howto/codeigniter.rst
+++ b/source/howto/codeigniter.rst
@@ -15,7 +15,7 @@ framework using Unit:
    <https://codeigniter.com/user_guide/tutorial/index.html>`_ your application.
    Here, let's use a `basic app template
    <https://forum.codeigniter.com/thread-73103.html>`_, installing it at
-   :file:`/path/to/app/`.
+   **/path/to/app/**.
 
 #. .. include:: ../include/howto_change_ownership.rst
 

--- a/source/howto/datasette.rst
+++ b/source/howto/datasette.rst
@@ -18,7 +18,7 @@ To run the `Datasette
 #. Running |app| on Unit requires a wrapper to expose the `application object
    <https://github.com/simonw/datasette/blob/4f7c0ebd85ccd8c1853d7aa0147628f7c1b749cc/datasette/app.py#L169>`_
    as the ASGI callable. Let's use the following basic version, saving it as
-   :file:`/path/to/app/asgi.py`:
+   **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -30,7 +30,7 @@ To run the `Datasette
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/django.rst
+++ b/source/howto/django.rst
@@ -13,12 +13,12 @@ using Unit:
 #. Install and configure the |app| `framework
    <https://www.djangoproject.com>`__.  The official docs `recommend
    <https://docs.djangoproject.com/en/stable/topics/install/#installing-an-official-release-with-pip>`_
-   setting up a virtual environment; if you do, list it as :samp:`home` when
-   configuring Unit later.  Here, it's :samp:`/path/to/venv/`.
+   setting up a virtual environment; if you do, list it as **home** when
+   configuring Unit later.  Here, it's **/path/to/venv/**.
 
 #. Create a |app| `project
    <https://docs.djangoproject.com/en/stable/intro/tutorial01/>`_.  Here, we
-   install it at :samp:`/path/to/app/`; use a real path in your configuration.
+   install it at **/path/to/app/**; use a real path in your configuration.
    The following steps assume your project uses `basic directory structure
    <https://docs.djangoproject.com/en/stable/ref/django-admin/#django-admin-startproject>`_:
 
@@ -39,22 +39,22 @@ using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, prepare the |app| :ref:`configuration <configuration-python>` for
-   Unit.  Here, the :file:`/path/to/app/` directory is stored in the
-   :samp:`path` option; the virtual environment is :samp:`home`; the WSGI or
-   ASGI module in the :file:`project/` subdirectory is `imported
-   <https://docs.python.org/3/reference/import.html>`_ via :samp:`module`.  If
+   Unit.  Here, the **/path/to/app/** directory is stored in the
+   **path** option; the virtual environment is **home**; the WSGI or
+   ASGI module in the **project/** subdirectory is `imported
+   <https://docs.python.org/3/reference/import.html>`_ via **module**.  If
    you reorder your directories, :ref:`set up <configuration-python>`
-   :samp:`path`, :samp:`home`, and :samp:`module` accordingly.
+   **path**, **home**, and **module** accordingly.
 
    You can also set up some environment variables that your project relies on,
-   using the :samp:`environment` option.  Finally, if your project uses |app|'s
+   using the **environment** option.  Finally, if your project uses |app|'s
    `static files
    <https://docs.djangoproject.com/en/stable/howto/static-files/>`_, optionally
    add a :ref:`route <configuration-routes>` to :ref:`serve
    <configuration-static>` them with Unit.
 
-   Here's an example (use real values for :samp:`share`, :samp:`path`,
-   :samp:`environment`, :samp:`module`, and :samp:`home`):
+   Here's an example (use real values for **share**, **path**,
+   **environment**, **module**, and **home**):
 
    .. tabs::
       :prefix: interface

--- a/source/howto/djangochannels.rst
+++ b/source/howto/djangochannels.rst
@@ -13,8 +13,8 @@ To run Django apps using the |app| `framework
 #. Install and configure the Django 3.0+ `framework
    <https://www.djangoproject.com>`__.  The official docs `recommend
    <https://docs.djangoproject.com/en/stable/topics/install/#installing-an-official-release-with-pip>`_
-   setting up a virtual environment; if you do, list it as :samp:`home` when
-   configuring Unit later.  Here, it's :samp:`/path/to/venv/`.
+   setting up a virtual environment; if you do, list it as **home** when
+   configuring Unit later.  Here, it's **/path/to/venv/**.
 
 #. Install |app| in your virtual environment:
 
@@ -27,7 +27,7 @@ To run Django apps using the |app| `framework
 
 #. Create a Django project.  Here, we'll use the `tutorial chat app
    <https://channels.readthedocs.io/en/stable/tutorial/part_1.html#tutorial-part-1-basic-setup>`_,
-   installing it at :samp:`/path/to/app/`; use a real path in your
+   installing it at **/path/to/app/**; use a real path in your
    configuration.  The following steps assume your project uses `basic
    directory structure
    <https://docs.djangoproject.com/en/stable/ref/django-admin/#django-admin-startproject>`_:
@@ -49,22 +49,22 @@ To run Django apps using the |app| `framework
    <https://channels.readthedocs.io/en/stable/tutorial/part_1.html#integrate-the-channels-library>`_.
 
 #. Next, create the |app| :ref:`configuration <configuration-python>` for
-   Unit.  Here, the :file:`/path/to/app/` directory is stored in the
-   :samp:`path` option; the virtual environment is :samp:`home`; the ASGI
-   module in the :file:`mysite/` subdirectory is `imported
-   <https://docs.python.org/3/reference/import.html>`_ via :samp:`module`.  If
+   Unit.  Here, the **/path/to/app/** directory is stored in the
+   **path** option; the virtual environment is **home**; the ASGI
+   module in the **mysite/** subdirectory is `imported
+   <https://docs.python.org/3/reference/import.html>`_ via **module**.  If
    you reorder your directories, :ref:`set up <configuration-python>`
-   :samp:`path`, :samp:`home`, and :samp:`module` accordingly.
+   **path**, **home**, and **module** accordingly.
 
    You can also set up some environment variables that your project relies on,
-   using the :samp:`environment` option.  Finally, if your project uses
+   using the **environment** option.  Finally, if your project uses
    Django's `static files
    <https://docs.djangoproject.com/en/stable/howto/static-files/>`_, optionally
    add a :ref:`route <configuration-routes>` to :ref:`serve
    <configuration-static>` them with Unit.
 
-   Here's an example (use real values for :samp:`share`, :samp:`path`,
-   :samp:`environment`, :samp:`module`, and :samp:`home`):
+   Here's an example (use real values for **share**, **path**,
+   **environment**, **module**, and **home**):
 
    .. code-block:: json
 

--- a/source/howto/docker.rst
+++ b/source/howto/docker.rst
@@ -19,8 +19,8 @@ For example:
      )
 
 The command mounts the host's current directory where your app files are stored
-to the container's :file:`/www/` directory and publishes the container's port
-:samp:`8000` that the listener will use as port :samp:`8080` on the host,
+to the container's **/www/** directory and publishes the container's port
+**8000** that the listener will use as port **8080** on the host,
 saving the container's ID in the :envvar:`UNIT` environment variable.
 
 Next, upload a configuration to Unit via the control socket:
@@ -31,9 +31,9 @@ Next, upload a configuration to Unit via the control socket:
          --unix-socket :nxt_hint:`/var/run/control.unit.sock <Socket path inside the container>`  \
          http://localhost/config
 
-This command assumes your configuration is stored as :file:`config.json` in the
+This command assumes your configuration is stored as **config.json** in the
 container-mounted directory on the host; if the file defines a listener on port
-:samp:`8000`, your app is now accessible on port :samp:`8080` of the host.  For
+**8000**, your app is now accessible on port **8080** of the host.  For
 details of the Unit configuration, see :ref:`Configuration
 <configuration-api>`.
 
@@ -59,7 +59,7 @@ Apps in a Containerized Unit
 ****************************
 
 Suppose we have a web app with a few dependencies, say :doc:`Flask's <flask>`
-official :samp:`hello, world` app:
+official **hello, world** app:
 
 .. code-block:: console
 
@@ -76,7 +76,7 @@ official :samp:`hello, world` app:
    EOF
 
 However basic it is, there's already a dependency, so let's list it in a file
-called :file:`requirements.txt`:
+called **requirements.txt**:
 
 .. code-block:: console
 
@@ -111,7 +111,7 @@ app:
    }
    EOF
 
-Finally, let's create :file:`log/` and :file:`state/` directories to store Unit
+Finally, let's create **log/** and **state/** directories to store Unit
 :ref:`log and state <source-startup>` respectively:
 
 .. code-block:: console
@@ -135,7 +135,7 @@ Our file structure so far:
        └── wsgi.py
 
 Everything is ready for a containerized Unit.  First, let's create a
-:file:`Dockerfile` to install app prerequisites:
+**Dockerfile** to install app prerequisites:
 
 .. subs-code-block:: docker
 
@@ -166,9 +166,9 @@ Next, we start a container and map it to our directory structure:
    default, our Docker images forward their log output to the `Docker log
    collector <https://docs.docker.com/config/containers/logging/>`_.
 
-We've mapped the source :file:`config/` to :file:`/docker-entrypoint.d/` in the
+We've mapped the source **config/** to **/docker-entrypoint.d/** in the
 container; the official image :ref:`uploads <installation-docker-init>` any
-:file:`.json` files found there into Unit's :samp:`config` section if the
+**.json** files found there into Unit's **config** section if the
 state is empty.  Now we can test the app:
 
 .. code-block:: console
@@ -185,7 +185,7 @@ structure:
    $ mv :nxt_ph:`/path/to/app/ <Directory where all app-related files are stored>` :nxt_ph:`/new/path/to/app/ <New directory; use a real path in your configuration>`
 
 To switch your app to a different Unit image, prepare a corresponding
-:file:`Dockerfile` first:
+**Dockerfile** first:
 
 .. subs-code-block:: docker
 
@@ -234,7 +234,7 @@ Containerized Apps
 ******************
 
 Suppose you have a Unit-ready :doc:`Express <express>` app, stored in the
-:file:`myapp/` directory as :file:`app.js`:
+**myapp/** directory as **app.js**:
 
    .. code-block:: javascript
 
@@ -248,7 +248,7 @@ Suppose you have a Unit-ready :doc:`Express <express>` app, stored in the
 
       http.createServer(app).listen()
 
-Its Unit configuration, stored as :file:`config.json` in the same directory:
+Its Unit configuration, stored as **config.json** in the same directory:
 
    .. code-block:: json
 
@@ -286,10 +286,10 @@ The resulting file structure:
 
 .. note::
 
-   Don't forget to :program:`chmod +x` the :samp:`app.js` file so Unit can run
+   Don't forget to :program:`chmod +x` the **app.js** file so Unit can run
    it.
 
-Let's prepare a :file:`Dockerfile` to install and configure the app in an
+Let's prepare a **Dockerfile** to install and configure the app in an
 image:
 
 .. subs-code-block:: docker
@@ -307,7 +307,7 @@ image:
    EXPOSE 8080
 
 When you start a container based on this image,
-mount the :file:`config.json` file to
+mount the **config.json** file to
 :ref:`initialize <installation-docker-init>`
 Unit's state:
 
@@ -328,7 +328,7 @@ Unit's state:
 .. note::
 
    This mechanism allows to initialize Unit at container startup only if its
-   state is empty; otherwise, the contents of :file:`/docker-entrypoint.d/` is
+   state is empty; otherwise, the contents of **/docker-entrypoint.d/** is
    ignored.  Continuing the previous sample:
 
    .. code-block:: console
@@ -345,8 +345,8 @@ Unit's state:
             -p 8080:8080 unit-expressapp                                                                   \
         )
 
-   Here, Unit *does not* pick up the :samp:`new-config.json` from the
-   :file:`/docker-entrypoint.d/` directory when we run a container from the
+   Here, Unit *does not* pick up the **new-config.json** from the
+   **/docker-entrypoint.d/** directory when we run a container from the
    updated image because Unit's state was initialized and saved earlier.
 
 To configure the app after startup, supply a file or an explicit snippet via
@@ -382,9 +382,9 @@ dependencies.
 Multilanguage Images
 ********************
 
-Earlier, Unit had a :samp:`-full` Docker image with modules for all supported
+Earlier, Unit had a **-full** Docker image with modules for all supported
 languages, but it was discontinued with version 1.22.0.  If you still need a
-multilanguage image, use the following :file:`Dockerfile` template that starts
+multilanguage image, use the following **Dockerfile** template that starts
 with the minimal Unit image based on :ref:`Debian 11 <installation-debian-11>`
 and installs official language module packages:
 
@@ -409,7 +409,7 @@ and installs official language module packages:
        && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*.list
 
 Instead of packages, you can build custom :ref:`modules
-<source-modules>`; use these :file:`Dockerfile.*` `templates
+<source-modules>`; use these **Dockerfile.*** `templates
 <https://github.com/nginx/unit/tree/master/pkg/docker>`__ as reference.
 
 
@@ -428,7 +428,7 @@ Dockerfile layer:
 
    CMD ["unitd-debug","--no-daemon","--control","unix:/var/run/control.unit.sock"]
 
-The :samp:`CMD` instruction above replaces the default :program:`unitd`
+The **CMD** instruction above replaces the default :program:`unitd`
 executable with its debug version.  Use Unit's :ref:`command-line options
 <source-startup>` to alter its startup behavior, for example:
 

--- a/source/howto/dokuwiki.rst
+++ b/source/howto/dokuwiki.rst
@@ -28,7 +28,7 @@ using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, prepare the app :ref:`configuration <configuration-php>` for Unit (use
-   real values for :samp:`share` and :samp:`root`):
+   real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -89,7 +89,7 @@ using Unit:
    After a successful update, your app should be available on the listener’s IP
    address and port.
 
-#. Browse to :samp:`/install.php` to complete your `installation
+#. Browse to **/install.php** to complete your `installation
    <https://www.dokuwiki.org/installer>`__:
 
    .. image:: ../images/dokuwiki.png

--- a/source/howto/drupal.rst
+++ b/source/howto/drupal.rst
@@ -21,9 +21,9 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit.
-   The default :file:`.htaccess` `scheme <https://github.com/drupal/drupal>`__
+   The default **.htaccess** `scheme <https://github.com/drupal/drupal>`__
    in a |app| installation roughly translates into the following (use real
-   values for :samp:`share` and :samp:`root`):
+   values for **share** and **root**):
 
    .. code-block:: json
 
@@ -137,13 +137,13 @@ Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of
-      the :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of
+      the **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the
-        URI or :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the
+        URI or **index.php** if the URI omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit
+      - The **index** target specifies the **script** that Unit
         runs for *any* URIs the target receives.
 
 #. .. include:: ../include/howto_upload_config.rst

--- a/source/howto/express.rst
+++ b/source/howto/express.rst
@@ -9,8 +9,8 @@ To run apps built with the `Express <https://expressjs.com>`_ web framework
 using Unit:
 
 #. Install :ref:`Unit <installation-precomp-pkgs>` with the
-   :samp:`unit-dev/unit-devel` package.  Next, :ref:`install
-   <installation-nodejs-package>` Unit's :samp:`unit-http` package:
+   **unit-dev/unit-devel** package.  Next, :ref:`install
+   <installation-nodejs-package>` Unit's **unit-http** package:
 
    .. code-block:: console
 
@@ -18,7 +18,7 @@ using Unit:
 
 #. Create your app directory, `install
    <https://expressjs.com/en/starter/installing.html>`_ |app|, and link
-   :samp:`unit-http`:
+   **unit-http**:
 
    .. code-block:: console
 
@@ -29,7 +29,7 @@ using Unit:
 
 #. Create your Express `app
    <https://expressjs.com/en/starter/hello-world.html>`_; let's store it as
-   :file:`/path/to/app/app.js`.  First, initialize the directory:
+   **/path/to/app/app.js**.  First, initialize the directory:
 
    .. code-block:: console
 

--- a/source/howto/falcon.rst
+++ b/source/howto/falcon.rst
@@ -31,8 +31,8 @@ web framework using Unit:
    .. warning::
 
       Create your virtual environment with a Python version that matches the
-      language module from Step |_| 1 up to the minor number (:samp:`X.Y` in
-      this example).  Also, the app :samp:`type` in Step |_| 5 must
+      language module from Step |_| 1 up to the minor number (**X.Y** in
+      this example).  Also, the app **type** in Step |_| 5 must
       :ref:`resolve <configuration-apps-common>` to a similarly matching
       version; Unit doesn't infer it from the environment.
 
@@ -69,7 +69,7 @@ web framework using Unit:
             app.add_route('/unit', hellounit)
 
          Note that we’ve dropped the server code; save the file as
-         :file:`/path/to/app/wsgi.py`.
+         **/path/to/app/wsgi.py**.
 
       .. tab:: ASGI
 
@@ -99,13 +99,13 @@ web framework using Unit:
             # hellounit will handle all requests to the '/unit' URL path
             app.add_route('/unit', hellounit)
 
-         Save the file as :file:`/path/to/app/asgi.py`.
+         Save the file as **/path/to/app/asgi.py**.
 
 4. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the configuration for Unit (use
-   real values for :samp:`type`, :samp:`home`, :samp:`module`,
-   :samp:`protocol`, and :samp:`path`):
+   real values for **type**, **home**, **module**,
+   **protocol**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/fastapi.rst
+++ b/source/howto/fastapi.rst
@@ -17,7 +17,7 @@ To run apps built with the `FastAPI
 
 #. Let's try a version of a `tutorial app
    <https://fastapi.tiangolo.com/tutorial/first-steps/>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -35,15 +35,15 @@ To run apps built with the `FastAPI
       `RealWorld example app
       <https://github.com/nsidnev/fastapi-realworld-example-app>`_; just
       install all its dependencies in the same virtual environment where you've
-      installed |app| and add the app's :samp:`environment` :ref:`variables
-      <configuration-apps-common>` like :samp:`DB_CONNECTION` or
-      :samp:`SECRET_KEY` directly to the app configuration in Unit instead of
-      the :file:`.env` file.
+      installed |app| and add the app's **environment** :ref:`variables
+      <configuration-apps-common>` like **DB_CONNECTION** or
+      **SECRET_KEY** directly to the app configuration in Unit instead of
+      the **.env** file.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/flask.rst
+++ b/source/howto/flask.rst
@@ -17,7 +17,7 @@ To run apps built with the `Flask
 
 #. Let's try a basic version of the `quickstart app
    <https://flask.palletsprojects.com/en/1.1.x/quickstart/>`_,
-   saving it as :file:`/path/to/app/wsgi.py`:
+   saving it as **/path/to/app/wsgi.py**:
 
    .. code-block:: python
 
@@ -31,7 +31,7 @@ To run apps built with the `Flask
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/grafana.rst
+++ b/source/howto/grafana.rst
@@ -11,7 +11,7 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
 
 #. .. include:: ../include/howto_install_unit.rst
 
-   Also, make sure Unit's Go module is available at :samp:`$GOPATH`.
+   Also, make sure Unit's Go module is available at **$GOPATH**.
 
 #. Download |app|'s source files:
 
@@ -28,7 +28,7 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
       $ curl -O https://unit.nginx.org/_downloads/grafana.patch
       $ patch -p1 < grafana.patch
 
-   Or update the sources manually.  In :file:`conf/defaults.ini`:
+   Or update the sources manually.  In **conf/defaults.ini**:
 
    .. code-block:: ini
       :emphasize-lines: 4
@@ -38,7 +38,7 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
       # Protocol (http, https, socket, unit)
       protocol = unit
 
-   In :file:`pkg/api/http_server.go`:
+   In **pkg/api/http_server.go**:
 
    .. code-block:: go
       :emphasize-lines: 4, 27-33
@@ -77,7 +77,7 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
               return nil
           }
 
-   In :file:`pkg/setting/setting.go`:
+   In **pkg/setting/setting.go**:
 
    .. code-block:: go
       :emphasize-lines: 5, 28-30
@@ -124,8 +124,8 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
       $ yarn install --pure-lockfile
       $ yarn start
 
-   Note the directory where the newly built :file:`grafana-server` is placed,
-   usually :file:`$GOPATH/bin/`; it's used for the :samp:`executable` option in
+   Note the directory where the newly built **grafana-server** is placed,
+   usually **$GOPATH/bin/**; it's used for the **executable** option in
    the Unit configuration.
 
 #. Run the following commands so Unit can access |app|'s files:
@@ -137,7 +137,7 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
 
    .. note::
 
-      The :samp:`unit:unit` user-group pair is available only with
+      The **unit:unit** user-group pair is available only with
       :ref:`official packages <installation-precomp-pkgs>`, Docker :ref:`images
       <installation-docker>`, and some :ref:`third-party repos
       <installation-community-repos>`.  Otherwise, account names may differ;
@@ -147,8 +147,8 @@ so we can :ref:`configure it <configuration-go>` to run on Unit.
    <security-apps>`.
 
 #. Next, :ref:`prepare <configuration-php>` the configuration (replace
-   :samp:`$GOPATH` with its value in :samp:`executable` and
-   :samp:`working_directory`):
+   **$GOPATH** with its value in **executable** and
+   **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/guillotina.rst
+++ b/source/howto/guillotina.rst
@@ -17,7 +17,7 @@ To run apps built with the `Guillotina
 
 #. Let's try a version of the `tutorial app
    <https://guillotina.readthedocs.io/en/latest/#build-a-guillotina-app>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -66,7 +66,7 @@ To run apps built with the `Guillotina
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/index.rst
+++ b/source/howto/index.rst
@@ -2,9 +2,9 @@
    :og:description: Run a variety of frameworks and applications, use Unit with
                     Docker, build custom modules, and resolve other issues.
 
-#####
-Howto
-#####
+######
+How-to
+######
 
 This section describes various real-life situations and issues that you may
 experience with Unit.

--- a/source/howto/integration.rst
+++ b/source/howto/integration.rst
@@ -26,12 +26,12 @@ Configure a :ref:`listener <configuration-listeners>` in Unit:
           }
       }
 
-Here, :samp:`forwarded` is optional; it enables identifying the
+Here, **forwarded** is optional; it enables identifying the
 :ref:`originating IPs <configuration-listeners-xff>` of requests proxied from
-:samp:`source`.
+**source**.
 
-In NGINX configuration, create an upstream in the :samp:`http` context, adding
-the listener's socket as a :samp:`server`:
+In NGINX configuration, create an upstream in the **http** context, adding
+the listener's socket as a **server**:
 
 .. code-block:: nginx
 
@@ -49,8 +49,8 @@ the listener's socket as a :samp:`server`:
        }
    }
 
-A more compact alternative would be a direct :samp:`proxy_pass` in your
-:samp:`location`:
+A more compact alternative would be a direct **proxy_pass** in your
+**location**:
 
 .. code-block:: nginx
 
@@ -64,8 +64,8 @@ A more compact alternative would be a direct :samp:`proxy_pass` in your
        }
    }
 
-The :samp:`proxy_set_header X-Forwarded-For` directives work together with the
-listener's :samp:`client_ip` option.
+The **proxy_set_header X-Forwarded-For** directives work together with the
+listener's **client_ip** option.
 
 For details, see the `NGINX documentation <https://nginx.org>`_.  Commercial
 support and advanced features are `also available <https://www.nginx.com>`_.
@@ -87,9 +87,9 @@ only.  To enable secure remote access, you can use NGINX as a reverse proxy.
    or a different solution such as SSH for security and authentication.
 
 Use this configuration template for NGINX (replace placeholders in
-:samp:`ssl_certificate`, :samp:`ssl_certificate_key`,
-:samp:`ssl_client_certificate`, :samp:`allow`, :samp:`auth_basic_user_file`,
-and :samp:`proxy_pass` with real values):
+**ssl_certificate**, **ssl_certificate_key**,
+**ssl_client_certificate**, **allow**, **auth_basic_user_file**,
+and **proxy_pass** with real values):
 
 .. code-block:: nginx
 

--- a/source/howto/jira.rst
+++ b/source/howto/jira.rst
@@ -27,7 +27,7 @@ To run `Atlassian Jira <https://www.atlassian.com/software/jira>`_ using Unit:
       $ curl https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-8.19.1.tar.gz -O -C -
       $ tar xzf atlassian-jira-core-8.19.1.tar.gz --strip-components 1
 
-#. Download |app|'s third-party dependencies to the :samp:`lib` subdirectory:
+#. Download |app|'s third-party dependencies to the **lib** subdirectory:
 
    .. code-block:: console
 
@@ -43,12 +43,12 @@ To run `Atlassian Jira <https://www.atlassian.com/software/jira>`_ using Unit:
       $ curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-plus/11.0.6/jetty-plus-10.0.6.jar -O -C -
       $ curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/11.0.6/jetty-util-10.0.6.jar -O -C -
 
-   Later, these :file:`.jar` files will be listed in the :samp:`classpath`
+   Later, these **.jar** files will be listed in the **classpath**
    option of the Unit configuration.
 
-#. Patch your |app| configuration, dropping :samp:`env` from the
-   :samp:`comp/env/UserTransaction` object path.  This ensures the
-   :samp:`UserTransaction` object will be found by your installation:
+#. Patch your |app| configuration, dropping **env** from the
+   **comp/env/UserTransaction** object path.  This ensures the
+   **UserTransaction** object will be found by your installation:
 
    .. code-block:: console
 
@@ -59,7 +59,7 @@ To run `Atlassian Jira <https://www.atlassian.com/software/jira>`_ using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`put together <configuration-java>` the |app| configuration (use
-   real values for :samp:`working_directory` and :samp:`jira.home`):
+   real values for **working_directory** and **jira.home**):
 
    .. code-block:: json
 

--- a/source/howto/joomla.rst
+++ b/source/howto/joomla.rst
@@ -21,7 +21,7 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for
-   Unit (use real values for :samp:`share` and :samp:`root`):
+   Unit (use real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -74,13 +74,13 @@ Unit:
       }
 
    The first route step handles the admin section and all URLs that specify a
-   PHP script; the :samp:`direct` target doesn't set the :samp:`script` option
-   to be used by default, so Unit looks for the respective :file:`.php` file.
+   PHP script; the **direct** target doesn't set the **script** option
+   to be used by default, so Unit looks for the respective **.php** file.
 
-   The next step serves static files via a :samp:`share`.  Its :samp:`fallback`
+   The next step serves static files via a **share**.  Its **fallback**
    enables rewrite mechanics for `search-friendly URLs
    <https://docs.joomla.org/Enabling_Search_Engine_Friendly_(SEF)_URLs>`_.  All
-   requests go to the :samp:`index` target that runs the :file:`index.php`
+   requests go to the **index** target that runs the **index.php**
    script at Joomla's directory root.
 
 #. .. include:: ../include/howto_upload_config.rst

--- a/source/howto/koa.rst
+++ b/source/howto/koa.rst
@@ -8,15 +8,15 @@ Koa
 To run apps built with the `Koa <https://koajs.com>`_ web framework using Unit:
 
 #. Install :ref:`Unit <installation-precomp-pkgs>` with the
-   :samp:`unit-dev/unit-devel` package.  Next, :ref:`install
-   <installation-nodejs-package>` Unit's :samp:`unit-http` package:
+   **unit-dev/unit-devel** package.  Next, :ref:`install
+   <installation-nodejs-package>` Unit's **unit-http** package:
 
    .. code-block:: console
 
       # npm install -g --unsafe-perm unit-http
 
 #. Create your app directory, `install <https://koajs.com/#introduction>`_
-   |app|, and link :samp:`unit-http`:
+   |app|, and link **unit-http**:
 
    .. code-block:: console
 
@@ -27,7 +27,7 @@ To run apps built with the `Koa <https://koajs.com>`_ web framework using Unit:
 
 #. Let’s try a version of the `tutorial app
    <https://koajs.com/#application>`__, saving it as
-   :file:`/path/to/app/app.js`:
+   **/path/to/app/app.js**:
 
    .. code-block:: javascript
 

--- a/source/howto/laravel.rst
+++ b/source/howto/laravel.rst
@@ -15,7 +15,7 @@ To run apps based on the `Laravel <https://laravel.com>`_ framework using Unit:
 
 #. Create a |app| `project
    <https://laravel.com/docs/installation#installation-via-composer>`__.
-   For our purposes, the path is :file:`/path/to/app/`:
+   For our purposes, the path is **/path/to/app/**:
 
    .. code-block:: console
 
@@ -30,7 +30,7 @@ To run apps based on the `Laravel <https://laravel.com>`_ framework using Unit:
       <https://laravel.com/docs/structure>`_.
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for
-   Unit (use real values for :samp:`share` and :samp:`root`):
+   Unit (use real values for **share** and **root**):
 
    .. code-block:: json
 

--- a/source/howto/lumen.rst
+++ b/source/howto/lumen.rst
@@ -16,7 +16,7 @@ Unit:
 
 #. Create a |app| `project
    <https://lumen.laravel.com/docs/8.x#installing-lumen>`__.
-   For our purposes, the path is :file:`/path/to/app/`:
+   For our purposes, the path is **/path/to/app/**:
 
    .. code-block:: console
 
@@ -26,7 +26,7 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for
-   Unit (use real values for :samp:`share` and :samp:`root`):
+   Unit (use real values for **share** and **root**):
 
    .. code-block:: json
 

--- a/source/howto/mailman.rst
+++ b/source/howto/mailman.rst
@@ -18,10 +18,10 @@ To install and run the web UI for the `Mailman 3
    we'll use Unit instead.  Also, note the following settings (values from the
    guide are given after the colon):
 
-   - Virtual environment path: :file:`/opt/mailman/venv/`
-   - Installation path: :file:`/etc/mailman3/`
-   - Static file path: :file:`/opt/mailman/web/static/`
-   - User and group: :samp:`mailman:mailman`
+   - Virtual environment path: **/opt/mailman/venv/**
+   - Installation path: **/etc/mailman3/**
+   - Static file path: **/opt/mailman/web/static/**
+   - User and group: **mailman:mailman**
 
    These are needed to configure Unit.
 
@@ -32,7 +32,7 @@ To install and run the web UI for the `Mailman 3
       # chown -R :nxt_hint:`unit:unit <User and group that Unit's router runs as by default>` :nxt_hint:`/opt/mailman/web/static/ <Mailman's static file path>`
    .. note::
 
-      The :samp:`unit:unit` user-group pair is available only with
+      The **unit:unit** user-group pair is available only with
       :ref:`official packages <installation-precomp-pkgs>`, Docker :ref:`images
       <installation-docker>`, and some :ref:`third-party repos
       <installation-community-repos>`.  Otherwise, account names may differ;
@@ -46,7 +46,7 @@ To install and run the web UI for the `Mailman 3
       # usermod -a -G :nxt_hint:`mailman <Mailman's user group noted in Step 2>` :nxt_hint:`unit <User that Unit's router runs as by default>`
 
 #. Next, prepare the |app| :ref:`configuration <configuration-python>` for Unit
-   (use values from Step 2 for :samp:`share`, :samp:`path`, and :samp:`home`):
+   (use values from Step 2 for **share**, **path**, and **home**):
 
    .. code-block:: json
 

--- a/source/howto/matomo.rst
+++ b/source/howto/matomo.rst
@@ -20,8 +20,8 @@ To run the `Matomo <https://matomo.org>`_ web analytics platform using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`).  The default
-   :file:`.htaccess` scheme in a |app| installation roughly translates into the
+   (use real values for **share** and **root**).  The default
+   **.htaccess** scheme in a |app| installation roughly translates into the
    following:
 
    .. code-block:: json

--- a/source/howto/mediawiki.rst
+++ b/source/howto/mediawiki.rst
@@ -17,7 +17,7 @@ documentation platform using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`):
+   (use real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -113,13 +113,13 @@ documentation platform using Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the w omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the w omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit runs
+      - The **index** target specifies the **script** that Unit runs
         for *any* URIs the target receives.
 
 #. .. include:: ../include/howto_upload_config.rst
@@ -131,7 +131,7 @@ documentation platform using Unit:
       :width: 100%
       :alt: MediaWiki on Unit
 
-   Download the newly generated :file:`LocalSettings.php` file and place it
+   Download the newly generated **LocalSettings.php** file and place it
    `appropriately <https://www.mediawiki.org/wiki/Manual:Config_script>`_:
 
    .. code-block:: console
@@ -141,7 +141,7 @@ documentation platform using Unit:
       # mv LocalSettings.php :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`
 
 #. After installation, add a match condition to the first step to disable
-   access to the :file:`mw-config/` directory:
+   access to the **mw-config/** directory:
 
    .. code-block:: console
 

--- a/source/howto/mercurial.rst
+++ b/source/howto/mercurial.rst
@@ -21,8 +21,8 @@ control system using Unit:
 #. Unit :ref:`uses WSGI <configuration-python>` to run Python apps, so it
    requires a `wrapper
    <https://www.mercurial-scm.org/repo/hg/file/default/contrib/hgweb.wsgi>`_
-   script to publish a |app| repo.  Here, it's :file:`/path/to/app/hgweb.py`
-   (note the extension); the :samp:`application` callable is the entry
+   script to publish a |app| repo.  Here, it's **/path/to/app/hgweb.py**
+   (note the extension); the **application** callable is the entry
    point:
 
     .. code-block:: python
@@ -39,7 +39,7 @@ control system using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, prepare the |app| :ref:`configuration
-   <configuration-python>` for Unit (use a real value for :samp:`path`):
+   <configuration-python>` for Unit (use a real value for **path**):
 
    .. code-block:: json
 

--- a/source/howto/modules.rst
+++ b/source/howto/modules.rst
@@ -155,7 +155,7 @@ adjust the command samples as needed to fit your scenario.
             $ cd $UNITTMP
 
          This creates a folder structure fit for :program:`dpkg-deb`; the
-         :file:`DEBIAN` folder will store the package definition.
+         **DEBIAN** folder will store the package definition.
 
       #. Run :program:`unitd --version` and note the :program:`./configure`
          :ref:`flags <source-config-src>` for later use, omitting
@@ -182,9 +182,9 @@ adjust the command samples as needed to fit your scenario.
             $ mkdir -p $UNITTMP/unit-php7.3/:nxt_ph:`MODULESPATH <Path to Unit's language modules>`                  # Use the module path set by ./configure or by default
             $ mv build/php7.3.unit.so $UNITTMP/unit-php7.3/:nxt_ph:`MODULESPATH <Path to Unit's language modules>`   # Adds the module to the package
 
-      #. Create a :file:`$UNITTMP/unit-php7.3/DEBIAN/control` `file
+      #. Create a **$UNITTMP/unit-php7.3/DEBIAN/control** `file
          <https://www.debian.org/doc/debian-policy/ch-controlfields.html>`__,
-         listing :samp:`unit` with other dependencies:
+         listing **unit** with other dependencies:
 
          .. subs-code-block:: control
 
@@ -231,7 +231,7 @@ adjust the command samples as needed to fit your scenario.
             # yum install -y rpmdevtools
             $ rpmdev-setuptree
 
-      #. Create a :file:`.spec` `file
+      #. Create a **.spec** `file
          <https://rpm-packaging-guide.github.io/#what-is-a-spec-file>`__
          to store build commands for your custom package:
 
@@ -251,7 +251,7 @@ adjust the command samples as needed to fit your scenario.
                 unit version: |version|
                 configured as ./configure :nxt_ph:`FLAGS <Note the flags, omitting --ld-opt and --njs>`
 
-      #. Edit the :file:`unit-php7.3.spec` file, adding the commands that
+      #. Edit the **unit-php7.3.spec** file, adding the commands that
          download Unit's sources, :ref:`configure
          <source-modules>` and build your custom module, then
          put it where Unit will find it:

--- a/source/howto/modx.rst
+++ b/source/howto/modx.rst
@@ -20,8 +20,8 @@ To run the `MODX <https://modx.com>`_ content application platform using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`).  The default
-   :file:`.htaccess` scheme in a |app| installation roughly translates into the
+   (use real values for **share** and **root**).  The default
+   **.htaccess** scheme in a |app| installation roughly translates into the
    following:
 
    .. code-block:: json

--- a/source/howto/moin.rst
+++ b/source/howto/moin.rst
@@ -12,7 +12,7 @@ MoinMoin
 
 .. warning::
 
-  So far, Unit doesn't support handling the :samp:`REMOTE_USER` headers
+  So far, Unit doesn't support handling the **REMOTE_USER** headers
   directly, so authentication should be implemented via other means.  For a
   full list of available authenticators, see `here
   <https://moinmo.in/HelpOnAuthentication>`_.
@@ -56,7 +56,7 @@ To run the `MoinMoin <https://moinmo.in/MoinMoinWiki>`_ wiki engine using Unit:
 
          Next, `edit
          <https://moinmo.in/HelpOnConfiguration#Configuring_a_single_wiki>`__
-         the wiki instance configuration in :file:`wikiconfig.py` as
+         the wiki instance configuration in **wikiconfig.py** as
          appropriate.
 
 
@@ -79,14 +79,14 @@ To run the `MoinMoin <https://moinmo.in/MoinMoinWiki>`_ wiki engine using Unit:
 
          Next, `edit
          <https://moinmo.in/HelpOnConfiguration#Configuration_of_multiple_wikis>`__
-         the farm configuration in :file:`farmconfig.py` and the wiki instance
-         configurations, shown here as :file:`wiki1.py` and :file:`wiki2.py`,
+         the farm configuration in **farmconfig.py** and the wiki instance
+         configurations, shown here as **wiki1.py** and **wiki2.py**,
          as appropriate.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`path`):
+   Unit (use real values for **path**):
 
    .. code-block:: json
 

--- a/source/howto/nextcloud.rst
+++ b/source/howto/nextcloud.rst
@@ -22,7 +22,7 @@ platform using Unit:
 
    .. note::
 
-      Verify the resulting settings in :file:`/path/to/app/config/config.php`;
+      Verify the resulting settings in **/path/to/app/config/config.php**;
       in particular, check the `trusted domains
       <https://docs.nextcloud.com/server/latest/admin_manual/installation/installation_wizard.html#trusted-domains-label>`_
       to ensure the installation is accessible within your network:
@@ -38,7 +38,7 @@ platform using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`put together <configuration-php>` the |app| configuration for
-   Unit (use real values for :samp:`share` and :samp:`root`).  The following is
+   Unit (use real values for **share** and **root**).  The following is
    based on NextCloud's own `guide
    <https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html>`_:
 
@@ -168,18 +168,18 @@ platform using Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the URI omits it.
 
-      - Other targets specify the :samp:`script` that Unit runs for *any* URIs
+      - Other targets specify the **script** that Unit runs for *any* URIs
         the target receives.
 
 #. .. include:: ../include/howto_upload_config.rst
 
-#. Adjust Unit's :samp:`max_body_size` :ref:`option <configuration-stngs>` to
+#. Adjust Unit's **max_body_size** :ref:`option <configuration-stngs>` to
    avoid potential issues with large file uploads, for example:
 
    .. code-block:: console

--- a/source/howto/opengrok.rst
+++ b/source/howto/opengrok.rst
@@ -12,14 +12,14 @@ To run the `OpenGrok
 
 #. Follow the official |app| `installation guide
    <https://github.com/oracle/opengrok/wiki/How-to-setup-OpenGrok>`_.  Here,
-   we'll place the files at :file:`/path/to/app/`:
+   we'll place the files at **/path/to/app/**:
 
    .. code-block:: console
 
       $ mkdir -p :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`{src,data,dist,etc,log}
       $ tar -C :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`dist --strip-components=1 -xzf opengrok-:nxt_ph:`X.Y.Z <Specific OpenGrok version>`.tar.gz
 
-   Our servlet container is Unit so we can repackage the :file:`source.war`
+   Our servlet container is Unit so we can repackage the **source.war**
    file to an arbitrary directory at `Step 2
    <https://github.com/oracle/opengrok/wiki/How-to-setup-OpenGrok#step2---deploy-the-web-application>`_:
 
@@ -28,7 +28,7 @@ To run the `OpenGrok
       $ opengrok-deploy -c :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`etc/configuration.xml  \
             :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`dist/lib/source.war :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`
 
-   The resulting pathname is :file:`/path/to/app/source.war`.
+   The resulting pathname is **/path/to/app/source.war**.
 
 #. .. include:: ../include/howto_change_ownership.rst
 

--- a/source/howto/phpbb.rst
+++ b/source/howto/phpbb.rst
@@ -20,7 +20,7 @@ To run the `phpBB <https://www.phpbb.com>`_ bulletin board using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, prepare the app :ref:`configuration <configuration-php>` for Unit (use
-   real values for :samp:`share` and :samp:`root`):
+   real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -94,13 +94,13 @@ To run the `phpBB <https://www.phpbb.com>`_ bulletin board using Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the URI omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit runs
+      - The **index** target specifies the **script** that Unit runs
         for *any* URIs the target receives.
 
 #. .. include:: ../include/howto_upload_config.rst
@@ -112,8 +112,8 @@ To run the `phpBB <https://www.phpbb.com>`_ bulletin board using Unit:
       :width: 100%
       :alt: phpBB on Unit
 
-#. Browse to :samp:`/install/app.php` to complete your installation.  Having
-   done that, delete the :file:`install/` subdirectory to mitigate security
+#. Browse to **/install/app.php** to complete your installation.  Having
+   done that, delete the **install/** subdirectory to mitigate security
    risks:
 
    .. code-block:: console

--- a/source/howto/phpmyadmin.rst
+++ b/source/howto/phpmyadmin.rst
@@ -19,7 +19,7 @@ To run the `phpMyAdmin <https://www.phpmyadmin.net>`_ web tool using Unit:
 
    .. note::
 
-      Make sure to create the :file:`config.inc.php` file `manually
+      Make sure to create the **config.inc.php** file `manually
       <https://docs.phpmyadmin.net/en/latest/setup.html#manually-creating-the-file>`__
       or using the `setup script
       <https://docs.phpmyadmin.net/en/latest/setup.html#using-the-setup-script>`__.
@@ -27,7 +27,7 @@ To run the `phpMyAdmin <https://www.phpmyadmin.net>`_ web tool using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`):
+   (use real values for **share** and **root**):
 
    .. code-block:: json
 

--- a/source/howto/plone.rst
+++ b/source/howto/plone.rst
@@ -17,7 +17,7 @@ To run the `Plone <https://plone.org>`_ content management system using Unit:
 
 #. .. include:: ../include/howto_install_prereq.rst
 
-#. Install |app|'s |app-link|_.  Here, we install it at :samp:`/path/to/app/`;
+#. Install |app|'s |app-link|_.  Here, we install it at **/path/to/app/**;
    use a real path in your configuration:
 
    .. code-block:: console
@@ -33,13 +33,13 @@ To run the `Plone <https://plone.org>`_ content management system using Unit:
    .. note::
 
       |app|'s `Zope <https://plone.org/what-is-plone/zope>`__ instance and
-      virtual environment are created in the :file:`zinstance/` subdirectory;
+      virtual environment are created in the **zinstance/** subdirectory;
       later, the resulting path is used to configure Unit, so take care to note
       it in your setup.  Also, make sure the Python version specified with
       :option:`!--with-python` matches the module version from Step 1.
 
 #. To run |app| on Unit, add a new configuration file named
-   :file:`/path/to/app/zinstance/wsgi.cfg`:
+   **/path/to/app/zinstance/wsgi.cfg**:
 
    .. code-block:: cfg
 
@@ -61,12 +61,12 @@ To run the `Plone <https://plone.org>`_ content management system using Unit:
           wsgiapp = make_wsgi_app({}, '${buildout:parts-directory}:nxt_hint:`/instance/etc/zope.conf <Path to the Zope instance's configuration>`')
           def application(*args, **kwargs):return wsgiapp(*args, **kwargs)
 
-   It creates a new Zope instance.  The part's name must end with :samp:`.py`
+   It creates a new Zope instance.  The part's name must end with **.py**
    for the resulting instance script to be recognized as a Python module; the
-   :samp:`initialization` `option
+   **initialization** `option
    <https://pypi.org/project/plone.recipe.zope2instance/#common-options>`__
-   defines a WSGI entry point using :file:`zope.conf` from the :samp:`instance`
-   part in :samp:`buildout.cfg`.
+   defines a WSGI entry point using **zope.conf** from the **instance**
+   part in **buildout.cfg**.
 
    Rerun Buildout, feeding it the new configuration file:
 
@@ -84,7 +84,7 @@ To run the `Plone <https://plone.org>`_ content management system using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for Unit
-   (use real values for :samp:`path` and :samp:`home`):
+   (use real values for **path** and **home**):
 
    .. code-block:: json
 

--- a/source/howto/pyramid.rst
+++ b/source/howto/pyramid.rst
@@ -17,8 +17,8 @@ using Unit:
 
    .. note::
 
-      Here, :samp:`$VENV` isn't set because Unit picks up the virtual
-      environment from :samp:`home` in Step |_| 5.
+      Here, **$VENV** isn't set because Unit picks up the virtual
+      environment from **home** in Step |_| 5.
 
 #. Let's see how the apps from the Pyramid `tutorial
    <https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial>`__
@@ -31,7 +31,7 @@ using Unit:
 
          We modify the `tutorial app
          <https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/hello_world.html#steps>`_,
-         saving it as :file:`/path/to/app/wsgi.py`:
+         saving it as **/path/to/app/wsgi.py**:
 
          .. code-block:: python
 
@@ -48,7 +48,7 @@ using Unit:
             # serve(app, host='0.0.0.0', port=6543)
 
          Note that we've dropped the server code; also, mind that Unit imports
-         the module, so the :samp:`if __name__ == '__main__'` idiom would be
+         the module, so the **if __name__ == '__main__'** idiom would be
          irrelevant.
 
 
@@ -56,8 +56,8 @@ using Unit:
 
          To load the `configuration
          <https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/ini.html>`__,
-         we place a :file:`wsgi.py` file next to :file:`development.ini` in
-         :file:`/path/to/app/`:
+         we place a **wsgi.py** file next to **development.ini** in
+         **/path/to/app/**:
 
          .. code-block:: python
 
@@ -68,15 +68,15 @@ using Unit:
 
          This `sets up
          <https://docs.pylonsproject.org/projects/pyramid/en/latest/api/paster.html>`__
-         the WSGI application for Unit; if the :file:`.ini`'s pathname is
-         relative, provide the appropriate :samp:`working_directory` in Unit
+         the WSGI application for Unit; if the **.ini**'s pathname is
+         relative, provide the appropriate **working_directory** in Unit
          configuration.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration
-   for Unit (use real values for :samp:`type`, :samp:`home`, and
-   :samp:`path`):
+   for Unit (use real values for **type**, **home**, and
+   **path**):
 
    .. code-block:: json
 

--- a/source/howto/quart.rst
+++ b/source/howto/quart.rst
@@ -17,7 +17,7 @@ To run apps built with the `Quart
 
 #. Let's try a WebSocket-enabled version of a `tutorial app
    <https://pgjones.gitlab.io/quart/tutorials/deployment.html>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -38,7 +38,7 @@ To run apps built with the `Quart
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/rails.rst
+++ b/source/howto/rails.rst
@@ -20,14 +20,14 @@ using Unit:
       $ cd :nxt_ph:`/path/to/ <Path where the application directory will be created; use a real path in your configuration>`
       $ rails new :nxt_ph:`app <Arbitrary app name; becomes the application directory name>`
 
-   This creates the app's directory tree at :file:`/path/to/app/`; its
-   :file:`public/` subdirectory contains the static files, while the entry
-   point is :file:`/path/to/app/config.ru`.
+   This creates the app's directory tree at **/path/to/app/**; its
+   **public/** subdirectory contains the static files, while the entry
+   point is **/path/to/app/config.ru**.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-ruby>` the |app| configuration (use real
-   values for :samp:`share` and :samp:`working_directory`):
+   values for **share** and **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/redmine.rst
+++ b/source/howto/redmine.rst
@@ -21,7 +21,7 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-ruby>` the |app| configuration for Unit
-   (use a real value for :samp:`working_directory`):
+   (use a real value for **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/responder.rst
+++ b/source/howto/responder.rst
@@ -17,7 +17,7 @@ To run apps built with the `Responder
 
 #. Let's try a Unit-friendly version of a `tutorial app
    <https://responder.kennethreitz.org/en/latest/quickstart.html#declare-a-web-service>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -33,14 +33,14 @@ To run apps built with the `Responder
       def hello_to(req, resp, *, who):
           resp.text = f"Hello, {who}!"
 
-   The :samp:`app.run()` call is omitted because :samp:`app` will be directly
+   The **app.run()** call is omitted because **app** will be directly
    run by Unit as an ASGI `callable
    <https://github.com/taoufik07/responder/blob/103816e27ae928d42ed850190472480124ba90e3/responder/api.py#L360>`_.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/reviewboard.rst
+++ b/source/howto/reviewboard.rst
@@ -22,7 +22,7 @@ To run the `Review Board
 
 #. Install the |app-link|_ and create a `site
    <https://www.reviewboard.org/docs/manual/dev/admin/installation/creating-sites/>`_.
-   Here, it's :samp:`/path/to/app/`; use a real path in your configuration:
+   Here, it's **/path/to/app/**; use a real path in your configuration:
 
    .. code-block:: console
 
@@ -38,7 +38,7 @@ To run the `Review Board
                 installation. This will only take a few minutes.
                 ...
 
-#. Add the :file:`.py` extension to the WSGI module's name to make it
+#. Add the **.py** extension to the WSGI module's name to make it
    discoverable by Unit, for example:
 
    .. code-block:: console
@@ -57,7 +57,7 @@ To run the `Review Board
       $ chmod u+w :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`data/
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`path`):
+   (use real values for **share** and **path**):
 
    .. code-block:: json
 

--- a/source/howto/roundcube.rst
+++ b/source/howto/roundcube.rst
@@ -20,7 +20,7 @@ To run the `Roundcube <https://roundcube.net>`_ webmail platform using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`):
+   (use real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -68,8 +68,8 @@ To run the `Roundcube <https://roundcube.net>`_ webmail platform using Unit:
       :width: 100%
       :alt: Roundcube on Unit - Setup Screen
 
-#. After installation, switch :samp:`share` and :samp:`root` to the
-   :file:`public_html/` subdirectory to `protect
+#. After installation, switch **share** and **root** to the
+   **public_html/** subdirectory to `protect
    <https://github.com/roundcube/roundcubemail/wiki/Installation#protect-your-installation>`__
    sensitive data:
 

--- a/source/howto/samples.rst
+++ b/source/howto/samples.rst
@@ -13,7 +13,7 @@ App Samples
 Go
 **
 
-Let's configure the following basic app, saved as :file:`/www/app.go`:
+Let's configure the following basic app, saved as **/www/app.go**:
 
 .. code-block:: go
 
@@ -123,7 +123,7 @@ Try this sample out with the Dockerfile :download:`here
 Java
 ****
 
-Let's configure the following basic app, saved as :file:`/www/index.jsp`:
+Let's configure the following basic app, saved as **/www/index.jsp**:
 
 .. code-block:: jsp
 
@@ -156,7 +156,7 @@ Try this sample out with the Dockerfile :download:`here
 <../downloads/Dockerfile.java.txt>` or use a more elaborate app example (you'll
 need to `download <https://cliftonlabs.github.io/json-simple/>`__ and :ref:`add
 <configuration-java>` the :program:`json-simple` library to your app's
-:samp:`classpath` option):
+**classpath** option):
 
 .. subs-code-block:: jsp
 
@@ -207,7 +207,7 @@ need to `download <https://cliftonlabs.github.io/json-simple/>`__ and :ref:`add
 Node.js
 *******
 
-Let's configure the following basic app, saved as :file:`/www/app.js`:
+Let's configure the following basic app, saved as **/www/app.js**:
 
 .. code-block:: javascript
 
@@ -279,7 +279,7 @@ Try this sample out with the Dockerfile :download:`here
 .. note::
 
    You can run a version of the same app :ref:`without
-   <configuration-nodejs-loader>` requiring the :samp:`unit-http` module
+   <configuration-nodejs-loader>` requiring the **unit-http** module
    explicitly.
 
 
@@ -289,7 +289,7 @@ Try this sample out with the Dockerfile :download:`here
 Perl
 ****
 
-Let's configure the following basic app, saved as :file:`/www/app.psgi`:
+Let's configure the following basic app, saved as **/www/app.psgi**:
 
 .. code-block:: perl
 
@@ -363,7 +363,7 @@ Try this sample out with the Dockerfile :download:`here
 PHP
 ***
 
-Let's configure the following basic app, saved as :file:`/www/index.php`:
+Let's configure the following basic app, saved as **/www/index.php**:
 
 .. code-block:: php
 
@@ -423,7 +423,7 @@ Try this sample out with the Dockerfile :download:`here
 Python
 ******
 
-Let's configure the following basic app, saved as :file:`/www/wsgi.py`:
+Let's configure the following basic app, saved as **/www/wsgi.py**:
 
 .. code-block:: python
 
@@ -486,7 +486,7 @@ Try this sample out with the Dockerfile :download:`here
 Ruby
 ****
 
-Let's configure the following basic app, saved as :file:`/www/config.ru`:
+Let's configure the following basic app, saved as **/www/config.ru**:
 
 .. code-block:: ruby
 
@@ -574,7 +574,7 @@ First, install the WebAssembly-specific Rust tooling:
 
 Next, initialize a new Rust project with a library target
 (apps are loaded by Unit's WebAssembly module as dynamic libraries).
-Then, add our :samp:`unit-wasm` crate
+Then, add our **unit-wasm** crate
 to enable the :program:`libunit-wasm` library:
 
 .. code-block:: console
@@ -583,14 +583,14 @@ to enable the :program:`libunit-wasm` library:
    $ cd wasm_on_unit/
    $ cargo add unit-wasm
 
-Append the following to :file:`Cargo.toml`:
+Append the following to **Cargo.toml**:
 
 .. code-block:: toml
 
    [lib]
    crate-type = ["cdylib"]
 
-Save some sample code from our :program:`unit-wasm` repo as :file:`src/lib.rs`:
+Save some sample code from our :program:`unit-wasm` repo as **src/lib.rs**:
 
 .. code-block:: console
 
@@ -603,7 +603,7 @@ Build the Rust module with WebAssembly as the target:
    $ cargo build --target wasm32-wasi
 
 This yields the
-:file:`target/wasm32-wasi/debug/wasm_on_unit.wasm` file
+**target/wasm32-wasi/debug/wasm_on_unit.wasm** file
 (path may depend on other options).
 
 Upload the :ref:`app config <configuration-wasm>` to Unit and test it:

--- a/source/howto/sanic.rst
+++ b/source/howto/sanic.rst
@@ -17,7 +17,7 @@ using Unit:
 
 #. Let's try a version of a `tutorial app
    <ttps://sanic.dev/en/guide/basics/response.html#methods>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -33,7 +33,7 @@ using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for
-   Unit (use real values for :samp:`type`, :samp:`home`, and :samp:`path`):
+   Unit (use real values for **type**, **home**, and **path**):
 
    .. code-block:: json
 

--- a/source/howto/security.rst
+++ b/source/howto/security.rst
@@ -31,7 +31,7 @@ versions shortly after they are released.
    - The recommended option is to use our official :ref:`packages
      <installation-precomp-pkgs>` or Docker :ref:`images
      <installation-docker>`; with them, it's just a matter of updating
-     :samp:`unit-*` packages with your package manager of choice or
+     **unit-*** packages with your package manager of choice or
      switching to a newer image.
 
    - If you use a third-party installation :ref:`method
@@ -60,7 +60,7 @@ safe.
 .. nxt_details:: Control Socket
    :hash: sec-socket
 
-   If you use a UNIX control socket, ensure it is available to :samp:`root`
+   If you use a UNIX control socket, ensure it is available to **root**
    only:
 
    .. subs-code-block:: console
@@ -135,8 +135,8 @@ safe.
    Avoid manipulating it or relying on its contents even if tempted to do so.
    Instead, use only the control API to manage Unit's configuration.
 
-   Also, the state directory should be available only to :samp:`root` (or the
-   user that the :samp:`main` :ref:`process <security-apps>` runs as):
+   Also, the state directory should be available only to **root** (or the
+   user that the **main** :ref:`process <security-apps>` runs as):
 
    .. subs-code-block:: console
 
@@ -187,7 +187,7 @@ clear and robust as possible to avoid loose ends and gaping holes.
    Some considerations:
 
    - Mind that :ref:`variables <configuration-variables>` contain arbitrary
-     user-supplied request values; variable-based :samp:`pass` values in
+     user-supplied request values; variable-based **pass** values in
      :ref:`listeners <configuration-listeners>` and :ref:`routes
      <configuration-routes-action>` must account for malicious requests, or the
      requests must be properly filtered.
@@ -211,7 +211,7 @@ files available across apps or even publicly.
 
 **Actions**: Properly configure your app directories and shares: apps and the
 router process need access to them.  Still, avoid loose rights such as the
-notorious :samp:`777`, instead assigning them on a need-to-know basis.
+notorious **777**, instead assigning them on a need-to-know basis.
 
 .. nxt_details:: File Permissions
    :hash: sec-files
@@ -291,7 +291,7 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
 
    #. A frequent source of issues is the lack of permissions for directories
       inside a directory path needed to run the app, so check for that if in
-      doubt.  Assuming your app code is stored at :samp:`/path/to/app/`:
+      doubt.  Assuming your app code is stored at **/path/to/app/**:
 
       .. code-block:: console
 
@@ -303,15 +303,15 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
 
                :nxt_hint:`drwxr-x--- <Permissions are too restrictive>`  some_user some_group  to
 
-      This may be a problem because the :samp:`to/` directory isn't owned by
-      :samp:`app_user:app_group` and denies all permissions to non-owners (as
-      the :samp:`---` sequence tells us), so a fix can be warranted:
+      This may be a problem because the **to/** directory isn't owned by
+      **app_user:app_group** and denies all permissions to non-owners (as
+      the **---** sequence tells us), so a fix can be warranted:
 
       .. code-block:: console
 
          # :nxt_hint:`chmod <Add read/execute permissions for non-owners>` o+rx /path/to/
 
-      Another solution is to add :samp:`app_user` to :samp:`some_group`
+      Another solution is to add **app_user** to **some_group**
       (assuming this was not done before):
 
       .. code-block:: console
@@ -474,8 +474,8 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
      to be freely downloadable nor your user-uploaded data to be executable as
      code, so configure your routes and apps to prevent both.
 
-   - Exposure of configuration data.  Your app-specific settings, :file:`.ini`
-     or :file:`.htaccess` files, and credentials are best kept hidden from
+   - Exposure of configuration data.  Your app-specific settings, **.ini**
+     or **.htaccess** files, and credentials are best kept hidden from
      prying eyes, and your routing configuration should reflect that.
 
    - Presence of hidden files from versioning, backups by text editors, and
@@ -554,8 +554,8 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
 
       * - Main
         - Yes
-        - Whoever starts the :file:`unitd` executable; by default,
-          :samp:`root`.
+        - Whoever starts the **unitd** executable; by default,
+          **root**.
         - Runs as a daemon, spawning Unit's non-privileged and app processes;
           requires numerous system capabilities and privileges for operation.
 
@@ -563,7 +563,7 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
         - No
         - Set by :option:`!--user` and :option:`!--group` options at
           :ref:`build <source-config-src>` or :ref:`execution
-          <source-startup>`; by default, :samp:`unit`.
+          <source-startup>`; by default, **unit**.
         - Serves the control API, accepting reconfiguration requests,
           sanitizing them, and passing them to other processes for
           implementation.
@@ -572,7 +572,7 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
         - No
         - Set by :option:`!--user` and :option:`!--group` options at
           :ref:`build <source-config-src>` or :ref:`execution
-          <source-startup>`; by default, :samp:`unit`.
+          <source-startup>`; by default, **unit**.
         - Discovers the language modules in the module directory at startup,
           then quits.
 
@@ -580,14 +580,14 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
         - No
         - Set by :option:`!--user` and :option:`!--group` options at
           :ref:`build <source-config-src>` or :ref:`execution
-          <source-startup>`; by default, :samp:`unit`.
+          <source-startup>`; by default, **unit**.
         - Serves client requests, accepting them, processing them on the spot,
           passing them to app processes, or proxying them further; requires
           access to static content paths you configure.
 
       * - App processes
         - No
-        - Set by per-app :samp:`user` and :samp:`group`
+        - Set by per-app **user** and **group**
           :ref:`options <configuration-applications>`; by default,
           :option:`!--user` and :option:`!--group` values.
         - Serve client requests that are routed to apps; require access to
@@ -606,7 +606,7 @@ notorious :samp:`777`, instead assigning them on a need-to-know basis.
             unit   ... unit: "front" application
 
    The important outtake here is to understand that Unit's non-privileged
-   processes don't require running as :samp:`root`.  Instead, they should have
+   processes don't require running as **root**.  Instead, they should have
    the minimal privileges required to operate, which so far means the ability
    to open connections and access the application code and the static files
    shared during routing.
@@ -676,13 +676,13 @@ disk space.
             ... unit: main v|version| [... --pid :nxt_ph:`/path/to/unit.pid <Make sure to check for runtime overrides>` --log :nxt_ph:`/path/to/unit.log <Make sure to check for runtime overrides>` ...]
 
    Another issue is the logs' accessibility.  Logs are opened and updated by
-   the :ref:`main process <security-apps>` that usually runs as :samp:`root`.
+   the :ref:`main process <security-apps>` that usually runs as **root**.
    However, to make them available for a certain consumer, you may need to
    enable access for a dedicated user that the consumer runs as.
 
    Perhaps, the most straightforward way to achieve this is to assign log
    ownership to the consumer's account.  Suppose you have a log utility running
-   as :samp:`log_user:log_group`:
+   as **log_user:log_group**:
 
    .. code-block:: console
 

--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -19,7 +19,7 @@ Perl, Python, and Ruby are supported>` and all other features you want in your
 Unit, such as TLS or regular expressions.
 
 The commands below assume you are configuring Unit with all supported languages
-and features (:samp:`X`, :samp:`Y`, and :samp:`Z` denote major, minor, and
+and features (**X**, **Y**, and **Z** denote major, minor, and
 revision numbers, respectively); omit the packages you won't use.
 
 .. tabs::
@@ -165,7 +165,7 @@ revision numbers, respectively); omit the packages you won't use.
       $ wget -O- https://github.com/bytecodealliance/wasmtime/releases/download/v12.0.0/wasmtime-v12.0.0-x86_64-linux-c-api.tar.xz \
             | tar Jxf -  # Unpacks to the current directory
 
-   Point to the resulting :file:`include` and :file:`lib` directories when
+   Point to the resulting **include** and **lib** directories when
    :ref:`configuring <howto/source-modules-webassembly>` the Unit code.
 
    To build WebAssembly apps that run on Unit, you will also need
@@ -188,14 +188,14 @@ revision numbers, respectively); omit the packages you won't use.
 Configuring Sources
 ===================
 
-To run system compatibility checks and generate a :file:`Makefile` with core
+To run system compatibility checks and generate a **Makefile** with core
 build instructions for Unit:
 
 .. code-block:: console
 
    $ ./configure :nxt_ph:`COMPILE-TIME OPTIONS <See the table below>`
 
-Finalize the resulting :file:`Makefile` by configuring the :ref:`language
+Finalize the resulting **Makefile** by configuring the :ref:`language
 modules <source-modules>` you need before proceeding further.
 
 General options and settings that control compilation, runtime privileges,
@@ -203,37 +203,37 @@ or support for certain features:
 
 .. list-table::
 
-   * - :samp:`--help`
+   * - **--help**
      -  Displays a summary of common :program:`./configure` options.
 
         For language-specific details, run :command:`./configure <language>
         --help` or see :ref:`below <source-modules>`.
 
-   * - :samp:`--cc=pathname`
+   * - **--cc=pathname**
      - Custom C compiler pathname.
 
-       The default is :samp:`cc`.
+       The default is **cc**.
 
-   * - :samp:`--cc-opt=options`, :samp:`--ld-opt=options`
+   * - **--cc-opt=options**, **--ld-opt=options**
      - Extra options for the C compiler and linker.
 
-   * - :samp:`--group=name`, :samp:`--user=name`
+   * - **--group=name**, **--user=name**
      - Group name and username to run Unit's non-privileged :ref:`processes
        <security-apps>`.
 
        The defaults are :option:`!--user`'s primary group and
-       :samp:`nobody`, respectively.
+       **nobody**, respectively.
 
-   * - :samp:`--debug`
+   * - **--debug**
      - Turns on the :ref:`debug log <troubleshooting-dbg-log>`.
 
-   * - :samp:`--no-ipv6`
+   * - **--no-ipv6**
      - Turns off IPv6 support.
 
-   * - :samp:`--no-unix-sockets`
+   * - **--no-unix-sockets**
      - Turns off UNIX domain sockets support for control and routing.
 
-   * - :samp:`--openssl`
+   * - **--openssl**
      - Turns on OpenSSL support.  Make sure OpenSSL (1.0.1+) header files and
        libraries are in your compiler's path; it can be set with the
        :option:`!--cc-opt` and :option:`!--ld-opt` options or the
@@ -252,11 +252,11 @@ PCRE2.  Two additional options alter this behavior:
 
 .. list-table::
 
-   * - :samp:`--no-regex`
+   * - **--no-regex**
      - Turns off regex support; any attempts to use a regex in Unit
        configuration cause an error.
 
-   * - :samp:`--no-pcre2`
+   * - **--no-pcre2**
      - Ignores PCRE2; the older PCRE 8.x library is used instead.
 
 .. _source-config-src-njs:
@@ -266,12 +266,12 @@ in configuration; to enable this feature, use the respective option:
 
 .. list-table::
 
-   * - :samp:`--njs`
-     - Turns on :program:`njs` support; requires :samp:`--openssl`.
+   * - **--njs**
+     - Turns on :program:`njs` support; requires **--openssl**.
 
 When :option:`!--njs` is enabled, the :option:`!--cc-opt` and
-:option:`!--ld-opt` option values should point to the :file:`src/`
-and :file:`build/` subdirectories of the :program:`njs` source code.
+:option:`!--ld-opt` option values should point to the **src/**
+and **build/** subdirectories of the :program:`njs` source code.
 For example, if you cloned the :program:`njs` repo beside the Unit repo:
 
 .. subs-code-block:: console
@@ -286,7 +286,7 @@ structure <source-dir>`:
 
 .. list-table::
 
-   * - :samp:`--prefix=PREFIX`
+   * - **--prefix=PREFIX**
      - .. _source-config-src-prefix:
 
        Destination directory prefix for :ref:`path options
@@ -307,41 +307,41 @@ structure <source-dir>`:
        :option:`!--pid`,
        :option:`!--log`.
 
-       The default is :samp:`/usr/local`.
+       The default is **/usr/local**.
 
-   * - :samp:`--exec-prefix=EXEC_PREFIX`
+   * - **--exec-prefix=EXEC_PREFIX**
      - Destination directory prefix for the executable directories only.
 
-       The default is the :samp:`PREFIX` value.
+       The default is the **PREFIX** value.
 
-   * - :samp:`--bindir=BINDIR`, :samp:`--sbindir=SBINDIR`
+   * - **--bindir=BINDIR**, **--sbindir=SBINDIR**
      - Directory paths for client and server executables.
 
-       The defaults are :samp:`EXEC_PREFIX/bin` and :samp:`EXEC_PREFIX/sbin`.
+       The defaults are **EXEC_PREFIX/bin** and **EXEC_PREFIX/sbin**.
 
-   * - :samp:`--includedir=INCLUDEDIR`, :samp:`--libdir=LIBDIR`
+   * - **--includedir=INCLUDEDIR**, **--libdir=LIBDIR**
      - Directory paths for :program:`libunit` header files and libraries.
 
-       The defaults are :samp:`PREFIX/include` and :samp:`EXEC_PREFIX/lib`.
+       The defaults are **PREFIX/include** and **EXEC_PREFIX/lib**.
 
-   * - :samp:`--modulesdir=MODULESDIR`
+   * - **--modulesdir=MODULESDIR**
      - Directory path for Unit's language :doc:`modules <modules>`.
 
-       The default is :samp:`LIBDIR/unit/modules`.
+       The default is **LIBDIR/unit/modules**.
 
-   * - :samp:`--datarootdir=DATAROOTDIR`, :samp:`--mandir=MANDIR`
-     - Directory path for :samp:`unitd(8)` data storage and its subdirectory
+   * - **--datarootdir=DATAROOTDIR**, **--mandir=MANDIR**
+     - Directory path for **unitd(8)** data storage and its subdirectory
        where the :program:`man` page is installed.
 
-       The defaults are :samp:`PREFIX/share` and :samp:`DATAROOTDIR/man`.
+       The defaults are **PREFIX/share** and **DATAROOTDIR/man**.
 
-   * - :samp:`--localstatedir=LOCALSTATEDIR`
+   * - **--localstatedir=LOCALSTATEDIR**
      - Directory path where Unit stores its runtime state, PID file,
        control socket, and logs.
 
-       The default is :samp:`PREFIX/var`.
+       The default is **PREFIX/var**.
 
-   * - :samp:`--libstatedir=LIBSTATEDIR`
+   * - **--libstatedir=LIBSTATEDIR**
      - .. _source-config-src-state:
 
        Directory path where Unit's runtime state (configuration, certificates,
@@ -350,30 +350,30 @@ structure <source-dir>`:
 
        .. warning::
 
-          The directory is sensitive and must be owned by :samp:`root` with
-          :samp:`700` permissions.  Don't change its contents externally; use
+          The directory is sensitive and must be owned by **root** with
+          **700** permissions.  Don't change its contents externally; use
           the config API to ensure integrity.
 
-       The default is :samp:`LOCALSTATEDIR/run/unit`.
+       The default is **LOCALSTATEDIR/run/unit**.
 
-   * - :samp:`--logdir=LOGDIR`, :samp:`--log=LOGFILE`
+   * - **--logdir=LOGDIR**, **--log=LOGFILE**
      - Directory path and filename for Unit's :ref:`log <troubleshooting-log>`.
 
-       The defaults are :samp:`LOCALSTATEDIR/log/unit` and
-       :samp:`LOGDIR/unit.log`.
+       The defaults are **LOCALSTATEDIR/log/unit** and
+       **LOGDIR/unit.log**.
 
-   * - :samp:`--runstatedir=RUNSTATEDIR`
+   * - **--runstatedir=RUNSTATEDIR**
      - Directory path where Unit stores its PID file and control socket.
 
-       The default is :samp:`LOCALSTATEDIR/run/unit`.
+       The default is **LOCALSTATEDIR/run/unit**.
 
-   * - :samp:`--pid=pathname`
+   * - **--pid=pathname**
      - Pathname for the PID file of Unit's :program:`main` :ref:`process
        <security-apps>`.
 
-       The default is :samp:`RUNSTATEDIR/unit.pid`.
+       The default is **RUNSTATEDIR/unit.pid**.
 
-   * - :samp:`--control=SOCKET`
+   * - **--control=SOCKET**
      - :ref:`Control API <configuration-mgmt>` socket address in IPv4, IPv6,
        or UNIX domain format:
 
@@ -389,14 +389,14 @@ structure <source-dir>`:
           :ref:`NGINX <nginx-secure-api>` or a different solution such as SSH
           for security and authentication.
 
-       The default is :samp:`unix:RUNSTATEDIR/control.unit.sock`, created as
-       :samp:`root` with :samp:`600` permissions.
+       The default is **unix:RUNSTATEDIR/control.unit.sock**, created as
+       **root** with **600** permissions.
 
-   * - :samp:`--tmpdir=TMPDIR`
+   * - **--tmpdir=TMPDIR**
      - Defines the temporary file storage location (used to dump large request
        bodies).
 
-       The default value is :samp:`/tmp`.
+       The default value is **/tmp**.
 
 
 .. _source-dir:
@@ -412,38 +412,38 @@ By default, :command:`make install` installs Unit at the following pathnames:
    * - Directory
      - Default Path
 
-   * - :samp:`bin` directory
-     - :file:`/usr/local/bin/`
+   * - **bin** directory
+     - **/usr/local/bin/**
 
-   * - :samp:`sbin` directory
-     - :file:`/usr/local/sbin/`
+   * - **sbin** directory
+     - **/usr/local/sbin/**
 
-   * - :samp:`lib` directory
-     - :file:`/usr/local/lib/`
+   * - **lib** directory
+     - **/usr/local/lib/**
 
-   * - :samp:`include` directory
-     - :file:`/usr/local/include/`
+   * - **include** directory
+     - **/usr/local/include/**
 
-   * - :samp:`tmp` directory
-     - :file:`/tmp/`
+   * - **tmp** directory
+     - **/tmp/**
 
    * - Man pages
-     - :file:`/usr/local/share/man/`
+     - **/usr/local/share/man/**
 
    * - Language modules
-     - :file:`/usr/local/lib/unit/modules/`
+     - **/usr/local/lib/unit/modules/**
 
    * - Runtime state
-     - :file:`/usr/local/var/lib/unit/`
+     - **/usr/local/var/lib/unit/**
 
    * - PID file
-     - :file:`/usr/local/var/run/unit/unit.pid`
+     - **/usr/local/var/run/unit/unit.pid**
 
    * - Log file
-     - :file:`/usr/local/var/log/unit/unit.log`
+     - **/usr/local/var/log/unit/unit.log**
 
    * - Control API socket
-     - :file:`unix:/usr/local/var/run/unit/control.unit.sock`
+     - **unix:/usr/local/var/run/unit/control.unit.sock**
 
 The defaults are designed to work for most cases; to customize this layout,
 set the :option:`!--prefix` and its related options during :ref:`configuration
@@ -458,7 +458,7 @@ Configuring Modules
 
 Next, configure a module for each language you want to use with Unit.  The
 :command:`./configure <language>` commands set up individual language modules
-and place module-specific instructions in the :file:`Makefile`.
+and place module-specific instructions in the **Makefile**.
 
 .. note::
 
@@ -479,16 +479,16 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--go=pathname`
+         * - **--go=pathname**
            - Specific Go executable pathname, also used in :ref:`make
              <source-bld-src-ext>` targets.
 
-             The default is :samp:`go`.
+             The default is **go**.
 
-         * - :samp:`--go-path=directory`
+         * - **--go-path=directory**
            - Custom directory path for Go package installation.
 
-             The default is :samp:`$GOPATH`.
+             The default is **$GOPATH**.
 
       .. note::
 
@@ -511,39 +511,39 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--home=directory`
+         * - **--home=directory**
            - Directory path for Java utilities and header files to build the
              module.
 
-             The default is the :samp:`java.home` setting.
+             The default is the **java.home** setting.
 
-         * - :samp:`--jars=directory`
-           - Directory path for Unit's custom :file:`.jar` files.
+         * - **--jars=directory**
+           - Directory path for Unit's custom **.jar** files.
 
              The default is the Java module path.
 
-         * - :samp:`--lib-path=directory`
-           - Directory path for the :file:`libjvm.so` library.
+         * - **--lib-path=directory**
+           - Directory path for the **libjvm.so** library.
 
              The default is based on JDK settings.
 
-         * - :samp:`--local-repo=directory`
-           - Directory path for the local :file:`.jar` repository.
+         * - **--local-repo=directory**
+           - Directory path for the local **.jar** repository.
 
-             The default is :samp:`$HOME/.m2/repository/`.
+             The default is **$HOME/.m2/repository/**.
 
-         * - :samp:`--repo=directory`
+         * - **--repo=directory**
            - URL path for the remote Maven repository.
 
-             The default is :samp:`http://central.maven.org/maven2/`.
+             The default is **http://central.maven.org/maven2/**.
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:file:`<basename>.unit.so`), also used
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also used
              in :ref:`make <source-bld-src-emb>` targets.
 
-             The default is :samp:`java`.
+             The default is **java**.
 
-      To configure a module called :file:`java11.unit.so` with OpenJDK |_|
+      To configure a module called **java11.unit.so** with OpenJDK |_|
       11.0.1:
 
       .. code-block:: console
@@ -560,27 +560,27 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--local=directory`
+         * - **--local=directory**
            - Local directory path where the resulting module is installed.
 
              By default, the module is installed globally :ref:`(recommended)
              <installation-nodejs-package>`.
 
-         * - :samp:`--node=pathname`
+         * - **--node=pathname**
            - Specific Node.js executable pathname, also used in
              :ref:`make <source-bld-src-ext>` targets.
 
-             The default is :samp:`node`.
+             The default is **node**.
 
-         * - :samp:`--npm=pathname`
+         * - **--npm=pathname**
            - Specific :program:`npm` executable pathname.
 
-             The default is :samp:`npm`.
+             The default is **npm**.
 
-         * - :samp:`--node-gyp=pathname`
+         * - **--node-gyp=pathname**
            - Specific :program:`node-gyp` executable pathname.
 
-             The default is :samp:`node-gyp`.
+             The default is **node-gyp**.
 
 
    .. tab:: Perl
@@ -591,18 +591,18 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--perl=pathname`
+         * - **--perl=pathname**
            - Specific Perl executable pathname.
 
-             The default is :samp:`perl`.
+             The default is **perl**.
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:file:`<basename>.unit.so`), also
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also
              used in :ref:`make <source-bld-src-emb>` targets.
 
              The default is the filename of the :option:`!--perl` executable.
 
-      To configure a module called :file:`perl-5.20.unit.so` for Perl |_|
+      To configure a module called **perl-5.20.unit.so** for Perl |_|
       5.20.2:
 
       .. code-block:: console
@@ -619,15 +619,15 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--config=pathname`
+         * - **--config=pathname**
            - Pathname of the :program:`php-config` script used to set up
              the resulting module.
 
-             The default is :samp:`php-config`.
+             The default is **php-config**.
 
-         * - :samp:`--lib-path=directory`
+         * - **--lib-path=directory**
            - Directory path of the :program:`libphp` library file
-             (:file:`libphp*.so` or :file:`libphp*.a`), usually available with
+             (**libphp*.so** or **libphp*.a**), usually available with
              an :option:`!--enable-embed` PHP build:
 
              .. code-block:: console
@@ -636,20 +636,20 @@ and place module-specific instructions in the :file:`Makefile`.
 
                       ... embed ...
 
-         * - :samp:`--lib-static`
-           - Links the static :program:`libphp` library (:file:`libphp*.a`)
-             instead of the dynamic one (:file:`libphp*.so`); requires
+         * - **--lib-static**
+           - Links the static :program:`libphp` library (**libphp*.a**)
+             instead of the dynamic one (**libphp*.so**); requires
              :option:`!--lib-path`.
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:file:`<basename>.unit.so`), also
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also
              used in :ref:`make <source-bld-src-emb>` targets.
 
              The default is :option:`!--config`'s filename minus the `-config`
-             suffix; thus, :samp:`--config=/path/php7-config` yields
-             :samp:`php7.unit.so`.
+             suffix; thus, **--config=/path/php7-config** yields
+             **php7.unit.so**.
 
-      To configure a module called :file:`php70.unit.so` for PHP |_| 7.0:
+      To configure a module called **php70.unit.so** for PHP |_| 7.0:
 
       .. code-block:: console
 
@@ -666,23 +666,23 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--config=pathname`
+         * - **--config=pathname**
            - Pathname of the :program:`python-config` script used to
              set up the resulting module.
 
-             The default is :samp:`python-config`.
+             The default is **python-config**.
 
-         * - :samp:`--lib-path=directory`
+         * - **--lib-path=directory**
            - Custom directory path of the Python runtime library to use with
              Unit.
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:samp:`<basename>.unit.so`), also
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also
              used in :ref:`make <source-bld-src-emb>` targets.
 
              The default is :option:`!--config`'s filename minus the `-config`
-             suffix; thus, :samp:`/path/python3-config` turns into
-             :samp:`python3`.
+             suffix; thus, **/path/python3-config** turns into
+             **python3**.
 
       .. note::
 
@@ -690,7 +690,7 @@ and place module-specific instructions in the :file:`Makefile`.
          compiled with the :option:`!--enable-shared` `option
          <https://docs.python.org/3/using/configure.html#linker-options>`__.
 
-      To configure a module called :file:`py33.unit.so` for Python |_| 3.3:
+      To configure a module called **py33.unit.so** for Python |_| 3.3:
 
       .. code-block:: console
 
@@ -706,18 +706,18 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:file:`<basename>.unit.so`), also
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also
              used in :ref:`make <source-bld-src-emb>` targets.
 
              The default is the filename of the :option:`!--ruby` executable.
 
-         * - :samp:`--ruby=pathname`
+         * - **--ruby=pathname**
            - Specific Ruby executable pathname.
 
-             The default is :samp:`ruby`.
+             The default is **ruby**.
 
-      To configure a module called :file:`ru23.unit.so` for Ruby |_| 2.3:
+      To configure a module called **ru23.unit.so** for Ruby |_| 2.3:
 
       .. code-block:: console
 
@@ -732,29 +732,29 @@ and place module-specific instructions in the :file:`Makefile`.
 
       .. list-table::
 
-         * - :samp:`--module=basename`
-           - Resulting module's name (:file:`<basename>.unit.so`), also
+         * - **--module=basename**
+           - Resulting module's name (**<basename>.unit.so**), also
              used in :ref:`make <source-bld-src-emb>` targets.
 
-         * - :samp:`--runtime=basename`
+         * - **--runtime=basename**
            - The WebAssembly runtime to use.
 
-             The default is :samp:`wasmtime`.
+             The default is **wasmtime**.
 
-         * - :samp:`--include-path=path`
+         * - **--include-path=path**
            - The directory path to the runtime's header files.
 
-         * - :samp:`--lib-path=path`
+         * - **--lib-path=path**
            - The directory path to the runtime's library files.
 
-         * - :samp:`--rpath=<path>`
+         * - **--rpath=<path>**
            - The directory path that designates the run-time library search
              path.
 
              If specified without a value,
-             assumes the :samp:`--lib-path` value.
+             assumes the **--lib-path** value.
 
-      To configure a module called :file:`wasm.unit.so`:
+      To configure a module called **wasm.unit.so**:
 
       .. code-block:: console
 
@@ -777,7 +777,7 @@ To build and install Unit's executables and language modules that you have
    $ make
    # make install
 
-Mind that :samp:`make install` requires setting up Unit's :ref:`directory
+Mind that **make install** requires setting up Unit's :ref:`directory
 structure <source-dir>` with :program:`./configure` first.
 
 To run Unit from the build directory tree without installing:
@@ -892,17 +892,17 @@ counterparts, see :ref:`here <source-config-src>`.
 
 .. list-table::
 
-   * - :samp:`--help`, :samp:`-h`
+   * - **--help**, **-h**
      - Displays a summary of the command-line options and their defaults.
 
-   * - :samp:`--version`
+   * - **--version**
      - Displays Unit's version and the :program:`./configure` settings it was
        built with.
 
-   * - :samp:`--no-daemon`
+   * - **--no-daemon**
      - Runs Unit in non-daemon mode.
 
-   * - :samp:`--control socket`
+   * - **--control socket**
      - Control API socket address in IPv4, IPv6, or UNIX domain format:
 
        .. code-block:: console
@@ -911,25 +911,25 @@ counterparts, see :ref:`here <source-config-src>`.
           # unitd --control [::1]:8080
           # unitd --control :nxt_hint:`unix:/path/to/control.unit.sock <Note the unix: prefix>`
 
-   * - :samp:`--group name`, :samp:`--user name`
+   * - **--group name**, **--user name**
      - Group name and user name used to run Unit's non-privileged
        :ref:`processes <security-apps>`.
 
-   * - :samp:`--log pathname`
+   * - **--log pathname**
      - Pathname for Unit's :ref:`log <troubleshooting-log>`.
 
-   * - :samp:`--modules directory`
+   * - **--modules directory**
      - Directory path for Unit's language :doc:`modules <modules>`
-       (:file:`*.unit.so` files).
+       (***.unit.so** files).
 
-   * - :samp:`--pid pathname`
+   * - **--pid pathname**
      - Pathname for the PID file of Unit's :program:`main` :ref:`process
        <security-apps>`.
 
-   * - :samp:`--state directory`
+   * - **--state directory**
      - Directory path for Unit's state storage.
 
-   * - :samp:`--tmp directory`
+   * - **--tmp directory**
      - Directory path for Unit's temporary file storage.
 
 Finally, to stop a running Unit:

--- a/source/howto/springboot.rst
+++ b/source/howto/springboot.rst
@@ -29,10 +29,10 @@ To run apps based on the `Spring Boot
 
       $ unzip :nxt_hint:`demo.zip <Downloaded project archive>` -d :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`
 
-   This creates a directory named :samp:`/path/to/app/demo/` for you to add
+   This creates a directory named **/path/to/app/demo/** for you to add
    your app code to; in our `example <https://spring.io/quickstart>`__, it's a
    single file called
-   :file:`/path/to/app/demo/src/main/java/com/example/demo/DemoApplication.java`:
+   **/path/to/app/demo/src/main/java/com/example/demo/DemoApplication.java**:
 
    .. code-block:: java
 
@@ -58,7 +58,7 @@ To run apps based on the `Spring Boot
         }
       }
 
-   Finally, assemble a :file:`.war` file.
+   Finally, assemble a **.war** file.
 
    If you chose `Gradle <https://gradle.org>`__ as the build tool:
 
@@ -76,14 +76,14 @@ To run apps based on the `Spring Boot
 
    .. note::
 
-     By default, Gradle puts the :file:`.war` file in the :file:`build/libs/`
-     subdirectory, while Maven uses :file:`target/`; note your path for later
+     By default, Gradle puts the **.war** file in the **build/libs/**
+     subdirectory, while Maven uses **target/**; note your path for later
      use in Unit configuration.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`put together <configuration-java>` the |app| configuration (use
-   a real value for :samp:`working_directory`):
+   a real value for **working_directory**):
 
    .. code-block:: json
 

--- a/source/howto/starlette.rst
+++ b/source/howto/starlette.rst
@@ -17,7 +17,7 @@ framework using Unit:
 
 #. Let's try a version of a `tutorial app
    <https://www.starlette.io/applications/>`_,
-   saving it as :file:`/path/to/app/asgi.py`:
+   saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
 
@@ -63,7 +63,7 @@ framework using Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for Unit
-   (use real values for :samp:`type`, :samp:`home`, and :samp:`path`), adding a
+   (use real values for **type**, **home**, and **path**), adding a
    :ref:`route <configuration-routes>` to serve static content:
 
    .. code-block:: json

--- a/source/howto/symfony.rst
+++ b/source/howto/symfony.rst
@@ -18,15 +18,15 @@ To run apps built with the `Symfony <https://symfony.com>`_ framework using Unit
       $ cd :nxt_ph:`/path/to/ <Path where the application directory will be created; use a real path in your configuration>`
       $ symfony new --demo :nxt_ph:`app <Arbitrary app name>`
 
-   This creates the app's directory tree at :file:`/path/to/app/`.  Its
-   :file:`public/` subdirectory contains both the root :file:`index.php` and
-   the static files; if your app requires additional :file:`.php` scripts, also
+   This creates the app's directory tree at **/path/to/app/**.  Its
+   **public/** subdirectory contains both the root **index.php** and
+   the static files; if your app requires additional **.php** scripts, also
    store them here.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`):
+   (use real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -79,13 +79,13 @@ To run apps built with the `Symfony <https://symfony.com>`_ framework using Unit
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the URI omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit runs
+      - The **index** target specifies the **script** that Unit runs
         for *any* URIs the target receives.
 
    For a detailed discussion, see `Configuring a Web Server

--- a/source/howto/trac.rst
+++ b/source/howto/trac.rst
@@ -7,7 +7,7 @@ Trac
 
 .. warning::
 
-  So far, Unit doesn't support handling the :samp:`REMOTE_USER` headers
+  So far, Unit doesn't support handling the **REMOTE_USER** headers
   directly, so authentication should be implemented via external means.  For
   example, consider using `trac-oidc <https://pypi.org/project/trac-oidc/>`_ or
   `OAuth2Plugin <https://trac-hacks.org/wiki/OAuth2Plugin>`_.
@@ -54,7 +54,7 @@ Unit:
 #. Unit :ref:`uses WSGI <configuration-python>` to run Python apps, so a
    `wrapper <https://trac.edgewall.org/wiki/1.3/TracModWSGI#Averybasicscript>`_
    script is required to run Trac as a Unit app; let's save it as
-   :file:`/path/to/app/trac_wsgi.py`.  Here, the :samp:`application` callable
+   **/path/to/app/trac_wsgi.py**.  Here, the **application** callable
    serves as the entry point for the app:
 
     .. code-block:: python
@@ -68,8 +68,8 @@ Unit:
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-python>` the |app| configuration for Unit
-   (use real values for :samp:`share`, :samp:`path`, :samp:`home`,
-   :samp:`module`, :samp:`TRAC_ENV`, and :samp:`PYTHON_EGG_CACHE`):
+   (use real values for **share**, **path**, **home**,
+   **module**, **TRAC_ENV**, and **PYTHON_EGG_CACHE**):
 
    .. code-block:: json
 
@@ -110,9 +110,9 @@ Unit:
           }
       }
 
-   The route serves requests for static files in Trac's :file:`/chrome/`
+   The route serves requests for static files in Trac's **/chrome/**
    `hierarchy <https://trac.edgewall.org/wiki/TracDev/TracURLs>`_ from the
-   :file:`static/` directory.
+   **static/** directory.
 
 #. .. include:: ../include/howto_upload_config.rst
 

--- a/source/howto/walkthrough.rst
+++ b/source/howto/walkthrough.rst
@@ -25,7 +25,7 @@ your technology stack, or simply be tech-curious.  In any case:
    * - **Get Unit on the system**
      - #. Install Unit with the language modules you need.  Your options:
 
-          - Official :samp:`.deb/.rpm` :ref:`packages
+          - Official **.deb/.rpm** :ref:`packages
             <installation-precomp-pkgs>`
 
           - Docker :ref:`images <installation-docker>`

--- a/source/howto/wordpress.rst
+++ b/source/howto/wordpress.rst
@@ -24,14 +24,14 @@ using Unit:
 
 #. .. include:: ../include/howto_install_app.rst
 
-#. Update the :file:`wp-config.php` `file
+#. Update the **wp-config.php** `file
    <https://wordpress.org/support/article/editing-wp-config-php/>`_ with your
    database settings and other customizations.
 
 #. .. include:: ../include/howto_change_ownership.rst
 
 #. Next, :ref:`prepare <configuration-php>` the |app| configuration for Unit
-   (use real values for :samp:`share` and :samp:`root`):
+   (use real values for **share** and **root**):
 
    .. code-block:: json
 
@@ -86,13 +86,13 @@ using Unit:
 
    .. note::
 
-      The difference between the :samp:`pass` targets is their usage of the
-      :samp:`script` :ref:`setting <configuration-php>`:
+      The difference between the **pass** targets is their usage of the
+      **script** :ref:`setting <configuration-php>`:
 
-      - The :samp:`direct` target runs the :samp:`.php` script from the URI or
-        defaults to :samp:`index.php` if the URI omits it.
+      - The **direct** target runs the **.php** script from the URI or
+        defaults to **index.php** if the URI omits it.
 
-      - The :samp:`index` target specifies the :samp:`script` that Unit runs
+      - The **index** target specifies the **script** that Unit runs
         for *any* URIs the target receives.
 
 #. .. include:: ../include/howto_upload_config.rst

--- a/source/howto/yii.rst
+++ b/source/howto/yii.rst
@@ -28,15 +28,15 @@ versions 1.1 or 2.0 using Unit:
             $ cd :nxt_ph:`/path/to/ <Partial path to the application directory; use a real path in your configuration>`
             $ composer create-project --prefer-dist yiisoft/yii2-app-basic :nxt_ph:`app <Arbitrary app name>`
 
-         This creates the app's directory tree at :file:`/path/to/app/`.
-         Its :file:`web/` subdirectory contains both the root
-         :file:`index.php` and the static files; if your app requires
-         additional :file:`.php` scripts, also store them here.
+         This creates the app's directory tree at **/path/to/app/**.
+         Its **web/** subdirectory contains both the root
+         **index.php** and the static files; if your app requires
+         additional **.php** scripts, also store them here.
 
       #. .. include:: ../include/howto_change_ownership.rst
 
       #. Next, :ref:`prepare <configuration-php>` the |app| configuration for
-         Unit (use real values for :samp:`share` and :samp:`root`):
+         Unit (use real values for **share** and **root**):
 
          .. code-block:: json
 
@@ -96,13 +96,13 @@ versions 1.1 or 2.0 using Unit:
 
          .. note::
 
-            The difference between the :samp:`pass` targets is their usage of
-            the :samp:`script` :ref:`setting <configuration-php>`:
+            The difference between the **pass** targets is their usage of
+            the **script** :ref:`setting <configuration-php>`:
 
-            - The :samp:`direct` target runs the :samp:`.php` script from the
-              URI or :samp:`index.php` if the URI omits it.
+            - The **direct** target runs the **.php** script from the
+              URI or **index.php** if the URI omits it.
 
-            - The :samp:`index` target specifies the :samp:`script` that Unit
+            - The **index** target specifies the **script** that Unit
               runs for *any* URIs the target receives.
 
       #. .. include:: ../include/howto_upload_config.rst
@@ -132,10 +132,10 @@ versions 1.1 or 2.0 using Unit:
             $ git clone git@github.com:yiisoft/yii.git :nxt_ph:`/path/to/yii1.1/ <Arbitrary framework path>`
             $ :nxt_ph:`/path/to/yii1.1/ <Arbitrary framework path>`framework/yiic webapp :nxt_ph:`/path/to/app/ <Path to the application directory; use a real path in your configuration>`
 
-         This creates the app's directory tree at :file:`/path/to/app/`.
+         This creates the app's directory tree at **/path/to/app/**.
 
       #. Next, :ref:`prepare <configuration-php>` the |app| configuration for
-         Unit (use real values for :samp:`share` and :samp:`root`):
+         Unit (use real values for **share** and **root**):
 
          .. code-block:: json
 
@@ -193,13 +193,13 @@ versions 1.1 or 2.0 using Unit:
 
          .. note::
 
-            The difference between the :samp:`pass` targets is their usage of
-            the :samp:`script` :ref:`setting <configuration-php>`:
+            The difference between the **pass** targets is their usage of
+            the **script** :ref:`setting <configuration-php>`:
 
-            - The :samp:`direct` target runs the :samp:`.php` script from the
-              URI or :samp:`index.php` if the URI omits it.
+            - The **direct** target runs the **.php** script from the
+              URI or **index.php** if the URI omits it.
 
-            - The :samp:`index` target specifies the :samp:`script` that Unit
+            - The **index** target specifies the **script** that Unit
               runs for *any* URIs the target receives.
 
       #. .. include:: ../include/howto_upload_config.rst

--- a/source/howto/zope.rst
+++ b/source/howto/zope.rst
@@ -14,7 +14,7 @@ Unit:
 
 #. .. include:: ../include/howto_install_unit.rst
 
-#. Install |app|.  Here, we do this at :samp:`/path/to/app/`; use a real path
+#. Install |app|.  Here, we do this at **/path/to/app/**; use a real path
    in your configuration.
 
    .. tabs::
@@ -35,7 +35,7 @@ Unit:
             $ buildout
 
          Next, add a new configuration file named
-         :file:`/path/to/app/wsgi.cfg`:
+         **/path/to/app/wsgi.cfg**:
 
          .. code-block:: cfg
 
@@ -58,8 +58,8 @@ Unit:
                 def application(*args, **kwargs):return wsgiapp(*args, **kwargs)
 
          It creates a new |app| instance.  The part's name must end with
-         :samp:`.py` for the resulting instance script to be recognized as a
-         Python module; the :samp:`initialization` `option
+         **.py** for the resulting instance script to be recognized as a
+         Python module; the **initialization** `option
          <https://pypi.org/project/plone.recipe.zope2instance/#common-options>`__
          defines a WSGI entry point.
 
@@ -78,7 +78,7 @@ Unit:
          .. include:: ../include/howto_change_ownership.rst
 
          Last, :ref:`prepare <configuration-python>` the |app| configuration
-         for Unit (use a real value for :samp:`path`):
+         for Unit (use a real value for **path**):
 
          .. code-block:: json
 
@@ -118,7 +118,7 @@ Unit:
 
             Create your virtual environment with a Python version that matches
             the language module from Step |_| 1 up to the minor number
-            (:samp:`3.Y` in this example).  Also, the app :samp:`type` in Unit
+            (**3.Y** in this example).  Also, the app **type** in Unit
             configuration must :ref:`resolve <configuration-apps-common>` to a
             similarly matching version; Unit doesn't infer it from the
             environment.
@@ -140,13 +140,13 @@ Unit:
             wsgiapp = make_wsgi_app({}, :nxt_hint:`str(Path(__file__).parent / 'etc/zope.conf' <Path to the instance's configuration file>`))
             def application(*args, **kwargs):return wsgiapp(*args, **kwargs)
 
-         Save the script as :file:`wsgi.py` in the instance home directory
-         (here, it's :file:`/path/to/app/instance/`).
+         Save the script as **wsgi.py** in the instance home directory
+         (here, it's **/path/to/app/instance/**).
 
          .. include:: ../include/howto_change_ownership.rst
 
          Last, :ref:`prepare <configuration-python>` the |app| configuration
-         for Unit (use real values for :samp:`path` and :samp:`home`):
+         for Unit (use real values for **path** and **home**):
 
          .. code-block:: json
 

--- a/source/include/howto_change_ownership.rst
+++ b/source/include/howto_change_ownership.rst
@@ -8,7 +8,7 @@ each one>`:
 
 .. note::
 
-   The :samp:`unit:unit` user-group pair is available only with :ref:`official
+   The **unit:unit** user-group pair is available only with :ref:`official
    packages <installation-precomp-pkgs>`, Docker :ref:`images
    <installation-docker>`, and some :ref:`third-party repos
    <installation-community-repos>`.  Otherwise, account names may differ; run

--- a/source/include/howto_install_app.rst
+++ b/source/include/howto_install_app.rst
@@ -1,2 +1,2 @@
-Install |app|'s |app-link|_.  Here, we install it at :samp:`/path/to/app/`; use
+Install |app|'s |app-link|_.  Here, we install it at **/path/to/app/**; use
 a real path in your configuration.

--- a/source/include/howto_install_venv.rst
+++ b/source/include/howto_install_venv.rst
@@ -15,7 +15,7 @@ Create a virtual environment to install |app|'s |app-pip-link|_:
 .. warning::
 
    Create your virtual environment with a Python version that matches the
-   language module from Step |_| 1 up to the minor number (:samp:`3.Y` in this
-   example).  Also, the app :samp:`type` in Step |_| 5 must :ref:`resolve
+   language module from Step |_| 1 up to the minor number (**3.Y** in this
+   example).  Also, the app **type** in Step |_| 5 must :ref:`resolve
    <configuration-apps-common>` to a similarly matching version; Unit doesn't
    infer it from the environment.

--- a/source/index.rst
+++ b/source/index.rst
@@ -5,7 +5,7 @@
 .. include:: include/replace.rst
 
 ########################
-Universal Web App Server
+Universal web app server
 ########################
 
 NGINX Unit is a lightweight and versatile application runtime

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -80,7 +80,7 @@ Optional dependencies:
 .. _installation-precomp-pkgs:
 
 *****************
-Official Packages
+Official packages
 *****************
 
 Installing an official precompiled Unit binary package
@@ -137,7 +137,7 @@ at the `npm <https://www.npmjs.com/package/unit-http>`_ registry.
    that install alongside the official Unit,
    see :ref:`here <modules-pkg>`.
 
-.. nxt_details:: Repo Installation Script
+.. nxt_details:: Repo installation script
    :hash: repo-install
 
    We provide a `script <https://github.com/nginx/unit/tree/master/tools>`__
@@ -168,7 +168,7 @@ Amazon Linux
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -193,13 +193,13 @@ Amazon Linux
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 2.0 LTS
@@ -208,7 +208,7 @@ Amazon Linux
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -233,13 +233,13 @@ Amazon Linux
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: AMI
@@ -254,7 +254,7 @@ Amazon Linux
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -279,13 +279,13 @@ Amazon Linux
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
 .. _installation-precomp-deb:
@@ -309,13 +309,13 @@ Debian
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -339,13 +339,13 @@ Debian
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 11
@@ -360,13 +360,13 @@ Debian
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -390,13 +390,13 @@ Debian
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 10
@@ -417,13 +417,13 @@ Debian
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -446,13 +446,13 @@ Debian
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 9
@@ -473,13 +473,13 @@ Debian
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -502,13 +502,13 @@ Debian
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
 .. _installation-precomp-fedora:
@@ -526,7 +526,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -551,13 +551,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 37
@@ -566,7 +566,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -591,13 +591,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 36, 35
@@ -612,7 +612,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -637,13 +637,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 34, 33
@@ -658,7 +658,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -683,13 +683,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 32
@@ -704,7 +704,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -729,13 +729,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 31, 30
@@ -751,7 +751,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -776,13 +776,13 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 29
@@ -797,7 +797,7 @@ Fedora
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -822,20 +822,20 @@ Fedora
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
 .. _installation-precomp-centos:
 .. _installation-precomp-rhel:
 
 ====================
-RHEL and Derivatives
+RHEL and derivatives
 ====================
 
 .. tabs::
@@ -847,7 +847,7 @@ RHEL and Derivatives
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -872,13 +872,13 @@ RHEL and Derivatives
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 8.x
@@ -887,7 +887,7 @@ RHEL and Derivatives
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -912,13 +912,13 @@ RHEL and Derivatives
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 7.x
@@ -931,7 +931,7 @@ RHEL and Derivatives
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -956,13 +956,13 @@ RHEL and Derivatives
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 6.x
@@ -977,7 +977,7 @@ RHEL and Derivatives
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/yum.repos.d/unit.repo`:
+         **/etc/yum.repos.d/unit.repo**:
 
          .. code-block:: ini
 
@@ -1002,13 +1002,13 @@ RHEL and Derivatives
       .. list-table::
 
          * - Control :ref:`socket <configuration-socket>`
-           - :file:`/var/run/unit/control.sock`
+           - **/var/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 .. note::
 
@@ -1041,13 +1041,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1070,13 +1070,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 22.10
@@ -1097,13 +1097,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1126,13 +1126,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 22.04
@@ -1147,13 +1147,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1176,13 +1176,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 21.10
@@ -1203,13 +1203,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1232,13 +1232,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 21.04
@@ -1259,13 +1259,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1288,13 +1288,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 20.10
@@ -1315,13 +1315,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1344,13 +1344,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 20.04
@@ -1365,13 +1365,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1394,13 +1394,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 19.10
@@ -1421,13 +1421,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1450,13 +1450,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 18.04
@@ -1477,13 +1477,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1506,13 +1506,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
    .. tab:: 16.04
@@ -1533,13 +1533,13 @@ Ubuntu
                   https://unit.nginx.org/keys/nginx-keyring.gpg
 
          This eliminates the
-         ``packages cannot be authenticated``
+         "packages cannot be authenticated"
          warnings
          during installation.
 
       #. To configure Unit's repository,
          create the following file named
-         :file:`/etc/apt/sources.list.d/unit.list`:
+         **/etc/apt/sources.list.d/unit.list**:
 
          .. code-block:: none
 
@@ -1562,13 +1562,13 @@ Ubuntu
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/var/run/control.unit.sock`
+           - **/var/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
 
 .. _installation-macos:
@@ -1610,17 +1610,17 @@ macOS
       .. list-table::
 
          * - Control :ref:`socket <sec-socket>`
-           - :file:`/usr/local/var/run/unit/control.sock` (Intel), :file:`/opt/homebrew/var/run/unit/control.sock` (Apple Silicon)
+           - **/usr/local/var/run/unit/control.sock** (Intel), **/opt/homebrew/var/run/unit/control.sock** (Apple Silicon)
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/usr/local/var/log/unit/unit.log` (Intel), :file:`/opt/homebrew/var/log/unit/unit.log` (Apple Silicon)
+           - **/usr/local/var/log/unit/unit.log** (Intel), **/opt/homebrew/var/log/unit/unit.log** (Apple Silicon)
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`nobody`
+           - **nobody**
 
 .. note::
 
-   To run Unit as :samp:`root` on macOS:
+   To run Unit as **root** on macOS:
 
    .. code-block:: console
 
@@ -1641,7 +1641,7 @@ is called
 Install it
 to run Node.js apps on Unit:
 
-#. First, install the :samp:`unit-dev/unit-devel`
+#. First, install the **unit-dev/unit-devel**
    :ref:`package <installation-precomp-pkgs>`;
    it's needed to build :program:`unit-http`.
 
@@ -1657,7 +1657,7 @@ to run Node.js apps on Unit:
        The :program:`unit-http` module is platform dependent
        due to optimizations;
        you can't move it across systems
-       with the rest of :file:`node-modules`.
+       with the rest of **node-modules**.
        Global installation avoids such scenarios;
        just
        :ref:`relink <configuration-nodejs>`
@@ -1666,9 +1666,9 @@ to run Node.js apps on Unit:
 #. It's entirely possible to run
    :ref:`Node.js apps <configuration-nodejs>`
    on Unit
-   without mentioning :samp:`unit-http` in your app sources.
-   However, you can explicitly use :samp:`unit-http` in your code
-   instead of the built-in :samp:`http`,
+   without mentioning **unit-http** in your app sources.
+   However, you can explicitly use **unit-http** in your code
+   instead of the built-in **http**,
    but mind that such frameworks as Express may require extra
    :doc:`changes <howto/express>`.
 
@@ -1687,7 +1687,7 @@ make sure to update the module as well:
    :ref:`install <source-bld-src-ext>`
    the :program:`unit-http` module from sources.
 
-.. nxt_details:: Working With Multiple Node.js Versions
+.. nxt_details:: Working with multiple Node.js versions
    :hash: multiple-nodejs-versions
 
    To use Unit with multiple Node.js versions side by side,
@@ -1762,7 +1762,7 @@ make sure to update the module as well:
 .. _installation-precomp-startup:
 
 ====================
-Startup and Shutdown
+Startup and shutdown
 ====================
 
 .. tabs::
@@ -1872,13 +1872,13 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/control.unit.sock`
+           - **/run/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit.log`
+           - **/var/log/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
          * - Startup and shutdown
            - .. code-block:: console
@@ -1904,7 +1904,7 @@ Community Repositories
          # service unit restart  # Necessary for Unit to pick up any changes in language module setup
 
       Versions of these packages
-      with the :samp:`*-debuginfo` suffix
+      with the ***-debuginfo** suffix
       contain symbols for
       :ref:`debugging <troubleshooting-core-dumps>`.
 
@@ -1913,13 +1913,13 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/unit/control.sock`
+           - **/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`_unit` (mind the :samp:`_` prefix)
+           - **_unit** (mind the **_** prefix)
 
          * - Startup and shutdown
            - .. code-block:: console
@@ -1943,7 +1943,7 @@ Community Repositories
          $ cd nginx-unit
 
       Before proceeding further,
-      verify that the :file:`PKGBUILD` and the accompanying files
+      verify that the **PKGBUILD** and the accompanying files
       aren't malicious or untrustworthy.
       AUR packages are user produced without pre-moderation;
       use them at your own risk.
@@ -1959,13 +1959,13 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/nginx-unit.control.sock`
+           - **/run/nginx-unit.control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/nginx-unit.log`
+           - **/var/log/nginx-unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`nobody`
+           - **nobody**
 
          * - Startup and shutdown
            - .. code-block:: console
@@ -2052,13 +2052,13 @@ Community Repositories
         .. list-table::
 
            * - Control :ref:`socket <source-startup>`
-             - :file:`/var/run/unit/control.unit.sock`
+             - **/var/run/unit/control.unit.sock**
 
            * - Log :ref:`file <troubleshooting-log>`
-             - :file:`/var/log/unit/unit.log`
+             - **/var/log/unit/unit.log**
 
            * - Non-privileged :ref:`user and group <security-apps>`
-             - :samp:`www`
+             - **www**
 
            * - Startup and shutdown
              - .. code-block:: console
@@ -2093,13 +2093,13 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/nginx-unit.sock`
+           - **/run/nginx-unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/nginx-unit`
+           - **/var/log/nginx-unit**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`nobody`
+           - **nobody**
 
          * - Startup and shutdown
            - .. code-block:: console
@@ -2161,9 +2161,9 @@ Community Repositories
       `unit-ruby
       <https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/www/unit-ruby/index.html>`__.
 
-      Note that :samp:`unit-php` packages require the PHP package
-      to be built with the :samp:`php-embed` option.
-      To enable the option for :samp:`lang/php82`:
+      Note that **unit-php** packages require the PHP package
+      to be built with the **php-embed** option.
+      To enable the option for **lang/php82**:
 
       .. code-block:: console
 
@@ -2180,17 +2180,17 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/var/run/unit/control.unit.sock`
+           - **/var/run/unit/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
          * - Startup and shutdown
            - First, add Unit's startup script
-             to the :file:`/etc/rc.d/` directory:
+             to the **/etc/rc.d/** directory:
 
              .. code-block:: console
 
@@ -2204,7 +2204,7 @@ Community Repositories
                 # :nxt_hint:`service unit stop <Stop a running Unit; one-time action>`
 
              To enable or disable Unit's automatic startup,
-             edit :file:`/etc/rc.conf`:
+             edit **/etc/rc.conf**:
 
              .. code-block:: ini
 
@@ -2239,7 +2239,7 @@ Community Repositories
       see the
       `package definition
       <https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/http/unit/default.nix>`_;
-      for a :file:`.nix` configuration file defining an app,
+      for a **.nix** configuration file defining an app,
       see
       `this sample
       <https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/web-servers/unit-php.nix>`_.
@@ -2249,17 +2249,17 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/unit/control.unit.sock`
+           - **/run/unit/control.unit.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`unit`
+           - **unit**
 
          * - Startup and shutdown
-           - Add :samp:`services.unit.enable = true;` to
-             :file:`/etc/nixos/configuration.nix`
+           - Add **services.unit.enable = true;** to
+             **/etc/nixos/configuration.nix**
              and rebuild the system configuration:
 
              .. code-block:: console
@@ -2328,13 +2328,13 @@ Community Repositories
         .. list-table::
 
            * - Control :ref:`socket <source-startup>`
-             - :file:`/var/run/unit/control.unit.sock`
+             - **/var/run/unit/control.unit.sock**
 
            * - Log :ref:`file <troubleshooting-log>`
-             - :file:`/var/log/unit/unit.log`
+             - **/var/log/unit/unit.log**
 
            * - Non-privileged :ref:`user and group <security-apps>`
-             - :samp:`_unit`
+             - **_unit**
 
            * - Startup and shutdown
              - .. code-block:: console
@@ -2377,13 +2377,13 @@ Community Repositories
       .. list-table::
 
          * - Control :ref:`socket <source-startup>`
-           - :file:`/run/unit/control.sock`
+           - **/run/unit/control.sock**
 
          * - Log :ref:`file <troubleshooting-log>`
-           - :file:`/var/log/unit/unit.log`
+           - **/var/log/unit/unit.log**
 
          * - Non-privileged :ref:`user and group <security-apps>`
-           - :samp:`nobody`
+           - **nobody**
 
          * - Startup and shutdown
            - .. code-block:: console
@@ -2409,52 +2409,52 @@ come in several language-specific flavors:
    * - Tag
      - Description
 
-   * - :samp:`|version|-minimal`
+   * - **|version|-minimal**
      - No language modules;
-       based on the :samp:`debian:bullseye-slim`
+       based on the **debian:bullseye-slim**
        `image <https://hub.docker.com/_/debian>`__.
 
-   * - :samp:`|version|-go1.21`
+   * - **|version|-go1.21**
      - Single-language;
-       based on the :samp:`golang:1.21`
+       based on the **golang:1.21**
        `image <https://hub.docker.com/_/golang>`__.
 
-   * - :samp:`|version|-jsc11`
+   * - **|version|-jsc11**
      - Single-language;
-       based on the :samp:`eclipse-temurin:11-jdk`
+       based on the **eclipse-temurin:11-jdk**
        `image <https://hub.docker.com/_/eclipse-temurin>`__.
 
-   * - :samp:`|version|-node20`
+   * - **|version|-node20**
      - Single-language;
-       based on the :samp:`node:20`
+       based on the **node:20**
        `image <https://hub.docker.com/_/node>`__.
 
-   * - :samp:`|version|-perl5.38`
+   * - **|version|-perl5.38**
      - Single-language;
-       based on the :samp:`perl:5.38`
+       based on the **perl:5.38**
        `image <https://hub.docker.com/_/perl>`__.
 
-   * - :samp:`|version|-php8.2`
+   * - **|version|-php8.2**
      - Single-language;
-       based on the :samp:`php:8.2-cli`
+       based on the **php:8.2-cli**
        `image <https://hub.docker.com/_/php>`__.
 
-   * - :samp:`|version|-python3.11`
+   * - **|version|-python3.11**
      - Single-language;
-       based on the :samp:`python:3.11`
+       based on the **python:3.11**
        `image <https://hub.docker.com/_/python>`__.
 
-   * - :samp:`|version|-ruby3.2`
+   * - **|version|-ruby3.2**
      - Single-language;
-       based on the :samp:`ruby:3.2`
+       based on the **ruby:3.2**
        `image <https://hub.docker.com/_/ruby>`__.
 
-   * - :samp:`|version|-wasm`
+   * - **|version|-wasm**
      - Single-language;
-       based on the :samp:`debian:bullseye-slim`
+       based on the **debian:bullseye-slim**
        `image <https://hub.docker.com/_/debian>`__.
 
-.. nxt_details:: Customizing Language Versions in Docker Images
+.. nxt_details:: Customizing language versions in Docker images
    :hash: inst-lang-docker
 
    To build a custom language version image,
@@ -2482,14 +2482,14 @@ come in several language-specific flavors:
       see the quick reference for its base image.
 
    The language name can be
-   :samp:`go`, :samp:`jsc`, :samp:`node`, :samp:`perl`,
-   :samp:`php`, :samp:`python`, or :samp:`ruby`;
-   the version is defined as :samp:`<major>.<minor>`,
-   except for :samp:`jsc` and :samp:`node`
+   **go**, **jsc**, **node**, **perl**,
+   **php**, **python**, or **ruby**;
+   the version is defined as **<major>.<minor>**,
+   except for **jsc** and **node**
    that take only major version numbers
    (as seen in the tag table).
    Thus, to create an image with Python 3.10
-   and tag it as :samp:`unit:|version|-python3.10`:
+   and tag it as **unit:|version|-python3.10**:
 
    .. subs-code-block:: console
 
@@ -2505,7 +2505,7 @@ come in several language-specific flavors:
    For other customization scenarios, see the
    :doc:`Docker howto <howto/docker>`.
 
-.. nxt_details:: Images With Pre-1.29.1 Unit Versions
+.. nxt_details:: Images with pre-1.29.1 Unit versions
    :hash: inst-pre-official-docker
 
    Before Unit 1.29.1 was released,
@@ -2514,7 +2514,7 @@ come in several language-specific flavors:
    `NGINX repository <https://hub.docker.com/r/nginx/unit/>`_
    on Docker Hub.
 
-.. nxt_details:: Images With Pre-1.22.0 Unit Versions
+.. nxt_details:: Images with pre-1.22.0 Unit versions
    :hash: inst-legacy-docker
 
    Before Unit 1.22.0 was released,
@@ -2526,15 +2526,15 @@ come in several language-specific flavors:
        * - Tag
          - Description
 
-       * - :samp:`<version>-full`
+       * - **<version>-full**
          - Contains modules for all languages that Unit then supported.
 
-       * - :samp:`<version>-minimal`
+       * - **<version>-minimal**
          - No language modules were included.
 
-       * - :samp:`<version>-<language>`
+       * - **<version>-<language>**
          - A specific language module
-           such as :samp:`1.21.0-ruby2.3` or :samp:`1.21.0-python2.7`.
+           such as **1.21.0-ruby2.3** or **1.21.0-python2.7**.
 
 You can obtain the images from these sources:
 
@@ -2590,7 +2590,7 @@ Runtime details:
 .. list-table::
 
    * - Control :ref:`socket <sec-socket>`
-     - :file:`/var/run/control.unit.sock`
+     - **/var/run/control.unit.sock**
 
    * - Log :ref:`file <troubleshooting-log>`
      - Forwarded to the
@@ -2598,7 +2598,7 @@ Runtime details:
        <https://docs.docker.com/config/containers/logging/>`_
 
    * - Non-privileged :ref:`user and group <security-apps>`
-     - :samp:`unit`
+     - **unit**
 
 For more details,
 see the repository pages
@@ -2611,19 +2611,19 @@ and our
 .. _installation-docker-init:
 
 =====================
-Initial Configuration
+Initial configuration
 =====================
 
 The official images support initial container configuration,
-implemented with an :samp:`ENTRYPOINT`
+implemented with an **ENTRYPOINT**
 `script <https://docs.docker.com/engine/reference/builder/#entrypoint>`_.
 First, the script checks the Unit
 :ref:`state directory <source-config-src-state>`
 in the container
-(:file:`/var/lib/unit/`).
+(**/var/lib/unit/**).
 If it's empty,
 the script processes certain file types
-in the container's :file:`/docker-entrypoint.d/` directory:
+in the container's **/docker-entrypoint.d/** directory:
 
 .. list-table::
    :header-rows: 1
@@ -2631,33 +2631,33 @@ in the container's :file:`/docker-entrypoint.d/` directory:
    * - File Type
      - Purpose/Action
 
-   * - :file:`.pem`
+   * - **.pem**
      - :ref:`Certificate bundles <configuration-ssl>`,
        uploaded under respective names:
-       :samp:`cert.pem` to :samp:`/certificates/cert`.
+       **cert.pem** to **/certificates/cert**.
 
-   * - :file:`.json`
+   * - **.json**
      - :ref:`Configuration snippets <configuration-mgmt>`, uploaded
-       to the :samp:`/config` section of Unit's configuration.
+       to the **/config** section of Unit's configuration.
 
-   * - :file:`.sh`
+   * - **.sh**
      - :nxt_hint:`Shell scripts
        <Use shebang in your scripts to specify a custom shell>`,
-       run after the :file:`.pem` and :file:`.json` files are uploaded;
+       run after the **.pem** and **.json** files are uploaded;
        must be executable.
 
 The script warns about any other file types
-in :file:`/docker-entrypoint.d/`.
+in **/docker-entrypoint.d/**.
 
 This mechanism enables
 customizing your containers at startup,
 reusing configurations,
 and automating workflows to reduce manual effort.
 To use the feature,
-add :samp:`COPY` directives for certificate bundles,
+add **COPY** directives for certificate bundles,
 configuration fragments,
 and shell scripts
-to your :file:`Dockerfile` derived from an official image:
+to your **Dockerfile** derived from an official image:
 
 .. subs-code-block:: docker
 

--- a/source/keyfeatures.rst
+++ b/source/keyfeatures.rst
@@ -4,7 +4,7 @@
 .. include:: include/replace.rst
 
 ############
-Key Features
+Key features
 ############
 
 From the start,
@@ -65,7 +65,7 @@ Flexibility
 
 - Originating IP identification
   :ref:`supports <configuration-listeners-xff>`
-  :samp:`X-Forwarded-For` and similar header fields.
+  **X-Forwarded-For** and similar header fields.
 
 
 ************
@@ -113,7 +113,7 @@ Performance
 
 
 *********************
-Security & Robustness
+Security & robustness
 *********************
 
 - Client connections
@@ -147,7 +147,7 @@ Security & Robustness
 
 
 ***********************
-Supported App Languages
+Supported app languages
 ***********************
 
 Unit interoperates with:

--- a/source/scripting.rst
+++ b/source/scripting.rst
@@ -17,30 +17,30 @@ with these
 :doc:`configuration <configuration>`
 options:
 
-- :samp:`pass` in
+- **pass** in
   :ref:`listeners <configuration-listeners>`
   and
   :ref:`actions <configuration-routes-action>`
   to choose between routes, applications, app targets, or upstreams.
 
-- :samp:`response_headers` values in
+- **response_headers** values in
   :ref:`actions <configuration-routes-action>`
   to manipulate response header fields.
 
-- :samp:`rewrite` in
+- **rewrite** in
   :ref:`actions <configuration-routes-action>`
   to enable :ref:`URI rewriting <configuration-rewrite>`.
 
-- :samp:`share` and :samp:`chroot` in
+- **share** and **chroot** in
   :ref:`actions <configuration-routes-action>`
   to control
   :ref:`static content serving <configuration-static>`.
 
-- :samp:`location` in :samp:`return`
+- **location** in **return**
   :ref:`actions <configuration-return>`
   to enable HTTP redirects.
 
-- :samp:`format` in the
+- **format** in the
   :ref:`access log <configuration-access-log>`
   to customize Unit's log output.
 
@@ -69,39 +69,39 @@ are exposed as :program:`njs` objects or scalars:
      - Type
      - Description
 
-   * - :samp:`args`
+   * - **args**
      - Object
      - Query string arguments;
-       :samp:`Color=Blue` is :samp:`args.Color`;
-       can be used with :samp:`Object.keys()`.
+       **Color=Blue** is **args.Color**;
+       can be used with **Object.keys()**.
 
-   * - :samp:`cookies`
+   * - **cookies**
      - Object
      - Request cookies;
-       an :samp:`authID` cookie is :samp:`cookies.authID`;
-       can be used with :samp:`Object.keys()`.
+       an **authID** cookie is **cookies.authID**;
+       can be used with **Object.keys()**.
 
-   * - :samp:`headers`
+   * - **headers**
      - Object
      - Request header fields;
-       :samp:`Accept` is :samp:`headers.Accept`,
-       :samp:`Content-Encoding` is :samp:`headers['Content-Encoding']`
+       **Accept** is **headers.Accept**,
+       **Content-Encoding** is **headers['Content-Encoding']**
        (hyphen requires an array property accessor);
-       can be used with :samp:`Object.keys()`.
+       can be used with **Object.keys()**.
 
-   * - :samp:`host`
+   * - **host**
      - Scalar
-     - :samp:`Host`
+     - **Host**
        `header field
        <https://datatracker.ietf.org/doc/html/rfc7230#section-5.4>`__,
        converted to lower case and normalized
        by removing the port number and the trailing period (if any).
 
-   * - :samp:`remoteAddr`
+   * - **remoteAddr**
      - Scalar
      - Remote IP address of the request.
 
-   * - :samp:`uri`
+   * - **uri**
      - Scalar
      - `Request target
        <https://datatracker.ietf.org/doc/html/rfc7230#section-5.3>`__,
@@ -117,20 +117,20 @@ are exposed as :program:`njs` objects or scalars:
 
 Template lterals are wrapped in backticks.
 To use a literal backtick in a string,
-escape it: :samp:`\\\\\\\\``
+escape it: **\\\\`**
 (escaping backslashes
 is a
 `JSON requirement
 <https://www.json.org/json-en.html>`_).
 The :program:`njs` snippets
 should be enclosed in curly brackets:
-:samp:`$\\{...\\}`.
+**${...}**.
 
 Next, you can upload and use custom JavaScript modules
 with your configuration.
-Consider this :file:`http.js` script
+Consider this **http.js** script
 that distinguishes requests
-by their :samp:`Authorization` header field values:
+by their **Authorization** header field values:
 
 .. code-block:: javascript
 
@@ -153,7 +153,7 @@ by their :samp:`Authorization` header field values:
    export default http
 
 To upload it to Unit's JavaScript module storage
-as :samp:`http`:
+as **http**:
 
 .. code-block:: console
 
@@ -161,7 +161,7 @@ as :samp:`http`:
          http://localhost/js_modules/:nxt_ph:`http <Module name in Unit's configuration>`
 
 Unit doesn't enable the uploaded modules by default,
-so add the module's name to :samp:`settings/js_module`:
+so add the module's name to **settings/js_module**:
 
 .. code-block:: console
 
@@ -170,11 +170,11 @@ so add the module's name to :samp:`settings/js_module`:
 
 .. note::
 
-   Mind that the :samp:`js_module` option
+   Mind that the **js_module** option
    can be a string or an array,
    so choose the appropriate HTTP method.
 
-Now, the :samp:`http.route()` function can be used
+Now, the **http.route()** function can be used
 with Unit-supplied header field values:
 
 .. code-block:: json
@@ -223,7 +223,7 @@ Examples
 
 This example adds simple routing logic
 that extracts the agent name
-from the :samp:`User-Agent` header field
+from the **User-Agent** header field
 to reject requests
 issued by :program:`curl`:
 

--- a/source/troubleshooting.rst
+++ b/source/troubleshooting.rst
@@ -33,7 +33,7 @@ To find out its default location in your installation:
        --log FILE           set log filename
                             default: "/path/to/unit.log"
 
-The :option:`!--log` option overrides the default value;
+The **--log** option overrides the default value;
 if Unit is already running,
 check whether this option is set:
 
@@ -45,22 +45,22 @@ check whether this option is set:
 
 If Unit isn't running,
 see its system startup scripts or configuration files
-to check if :option:`!--log` is set,
+to check if **--log** is set,
 and how.
 
 Available log levels:
 
-- :samp:`[alert]`: Non-fatal errors such as app exceptions or misconfigurations.
+- **[alert]**: Non-fatal errors such as app exceptions or misconfigurations.
 
-- :samp:`[error]`: Serious errors such as invalid ports or addresses.
+- **[error]**: Serious errors such as invalid ports or addresses.
 
-- :samp:`[warn]`: Recoverable issues such as :samp:`umount2(2)` failures.
+- **[warn]**: Recoverable issues such as **umount2(2)** failures.
 
-- :samp:`[notice]`: Self-diagnostic and router events.
+- **[notice]**: Self-diagnostic and router events.
 
-- :samp:`[info]`: General-purpose reporting.
+- **[info]**: General-purpose reporting.
 
-- :samp:`[debug]`: Debug events.
+- **[debug]**: Debug events.
 
 .. note::
 
@@ -72,10 +72,10 @@ Available log levels:
 .. _troubleshooting-router-log:
 
 =============
-Router Events
+Router events
 =============
 
-The :samp:`log_route` option
+The **log_route** option
 in Unit's
 :ref:`settings <configuration-stngs>`
 allows recording
@@ -90,23 +90,23 @@ in the general-purpose log:
       - Description
 
     * - HTTP request line
-      - :samp:`[notice]`
+      - **[notice]**
       - Incoming
         `request line
         <https://datatracker.ietf.org/doc/html/rfc9112#section-3>`__.
 
     * - URI rewritten
-      - :samp:`[notice]`
+      - **[notice]**
       - The request URI is updated.
 
     * - Route step selected
-      - :samp:`[notice]`
+      - **[notice]**
       - The route step is selected
         to serve the request.
 
     * - Fallback taken
-      - :samp:`[notice]`
-      - A :samp:`fallback` action is taken
+      - **[notice]**
+      - A **fallback** action is taken
         after the step is selected.
 
 Sample router logging output may look like this:
@@ -121,7 +121,7 @@ Sample router logging output may look like this:
    [notice] 8308#8339 *16 "fallback" taken
 
 It lists specific steps and actions
-(such as :samp:`routes/2`)
+(such as **routes/2**)
 that can be queried via the
 :doc:`control API <controlapi>`
 for details:
@@ -136,7 +136,7 @@ for details:
 Debug Events
 ============
 
-Unit's log can be set to record :samp:`[debug]`-level events;
+Unit's log can be set to record **[debug]**-level events;
 the steps to enable this mode
 vary by install method.
 
@@ -180,7 +180,7 @@ vary by install method.
 
          CMD ["unitd-debug","--no-daemon","--control","unix:/var/run/control.unit.sock"]
 
-      The :samp:`CMD` instruction above
+      The **CMD** instruction above
       replaces the default :program:`unitd` executable
       with its debug version.
 
@@ -189,7 +189,7 @@ vary by install method.
 
       To enable debug-level logging when
       :ref:`installing from source <source>`,
-      use the :option:`!--debug` option:
+      use the **--debug** option:
 
       .. code-block:: console
 
@@ -211,12 +211,12 @@ attach them when
 For builds from
 :ref:`our repositories <installation-precomp-pkgs>`,
 we maintain debug symbols in special packages;
-they have the original packages' names with the :samp:`-dbg` suffix appended,
-such as :samp:`unit-dbg`.
+they have the original packages' names with the **-dbg** suffix appended,
+such as **unit-dbg**.
 
 .. note::
 
-   This section assumes you're running Unit as :samp:`root` (recommended).
+   This section assumes you're running Unit as **root** (recommended).
 
 .. tabs::
    :prefix: core-dumps
@@ -231,7 +231,7 @@ such as :samp:`unit-dbg`.
       adjust the
       `service settings
       <https://www.freedesktop.org/software/systemd/man/systemd.exec.html>`_
-      in :file:`/lib/systemd/system/unit.service`:
+      in **/lib/systemd/system/unit.service**:
 
       .. code-block:: ini
 
@@ -244,7 +244,7 @@ such as :samp:`unit-dbg`.
       update the
       `global settings
       <https://www.freedesktop.org/software/systemd/man/systemd.directives.html>`_
-      in :file:`/etc/systemd/system.conf`:
+      in **/etc/systemd/system.conf**:
 
       .. code-block:: ini
 
@@ -284,7 +284,7 @@ such as :samp:`unit-dbg`.
       Check the
       `core dump settings
       <https://www.man7.org/linux/man-pages/man5/limits.conf.5.html>`__
-      in :file:`/etc/security/limits.conf`,
+      in **/etc/security/limits.conf**,
       adjusting them if necessary:
 
       .. code-block:: none
@@ -320,7 +320,7 @@ such as :samp:`unit-dbg`.
       Check the
       `core dump settings
       <https://www.freebsd.org/cgi/man.cgi?sysctl.conf(5)>`__
-      in :file:`/etc/sysctl.conf`,
+      in **/etc/sysctl.conf**,
       adjusting them if necessary:
 
       .. code-block:: ini

--- a/source/usagestats.rst
+++ b/source/usagestats.rst
@@ -7,11 +7,11 @@
 .. _configuration-stats:
 
 ****************
-Usage Statistics
+Usage statistics
 ****************
 
 Unit collects instance- and app-wide metrics,
-available via the :samp:`GET`-only :samp:`/status` section of the
+available via the **GET**-only **/status** section of the
 :ref:`control API <configuration-api>`:
 
 .. list-table::
@@ -20,15 +20,15 @@ available via the :samp:`GET`-only :samp:`/status` section of the
     * - Option
       - Description
 
-    * - :samp:`connections`
+    * - **connections**
       - Object;
         lists per-instance connection statistics.
 
-    * - :samp:`requests`
+    * - **requests**
       - Object;
         lists per-instance request statistics.
 
-    * - :samp:`applications`
+    * - **applications**
       - Object;
         each option item lists per-app process and request statistics.
 
@@ -63,7 +63,7 @@ Example:
        }
    }
 
-The :samp:`connections` object offers the following Unit instance metrics:
+The **connections** object offers the following Unit instance metrics:
 
 .. list-table::
     :header-rows: 1
@@ -71,19 +71,19 @@ The :samp:`connections` object offers the following Unit instance metrics:
     * - Option
       - Description
 
-    * - :samp:`accepted`
+    * - **accepted**
       - Integer;
         total accepted connections during the instance's lifetime.
 
-    * - :samp:`active`
+    * - **active**
       - Integer;
         current active connections for the instance.
 
-    * - :samp:`idle`
+    * - **idle**
       - Integer;
         current idle connections for the instance.
 
-    * - :samp:`closed`
+    * - **closed**
       - Integer;
         total closed connections during the instance's lifetime.
 
@@ -104,7 +104,7 @@ Example:
    refer to
    :ref:`configuration-stngs`.
 
-The :samp:`requests` object currently exposes a single instance-wide metric:
+The **requests** object currently exposes a single instance-wide metric:
 
 .. list-table::
     :header-rows: 1
@@ -112,7 +112,7 @@ The :samp:`requests` object currently exposes a single instance-wide metric:
     * - Option
       - Description
 
-    * - :samp:`total`
+    * - **total**
       - Integer;
         total non-API requests during the instance's lifetime.
 
@@ -124,8 +124,8 @@ Example:
        "total": 1307
    }
 
-Each item in :samp:`applications` describes an app
-currently listed in the :samp:`/config/applications`
+Each item in **applications** describes an app
+currently listed in the **/config/applications**
 :ref:`section <configuration-applications>`:
 
 .. list-table::
@@ -134,13 +134,13 @@ currently listed in the :samp:`/config/applications`
     * - Option
       - Description
 
-    * - :samp:`processes`
+    * - **processes**
       - Object;
         lists per-app process statistics.
 
-    * - :samp:`requests`
+    * - **requests**
       - Object;
-        similar to :samp:`/status/requests`,
+        similar to **/status/requests**,
         but includes only the data for a specific app.
 
 Example:
@@ -161,7 +161,7 @@ Example:
        }
    }
 
-The :samp:`processes` object exposes the following per-app metrics:
+The **processes** object exposes the following per-app metrics:
 
 .. list-table::
     :header-rows: 1
@@ -169,15 +169,15 @@ The :samp:`processes` object exposes the following per-app metrics:
     * - Option
       - Description
 
-    * - :samp:`running`
+    * - **running**
       - Integer;
         current running app processes.
 
-    * - :samp:`starting`
+    * - **starting**
       - Integer;
         current starting app processes.
 
-    * - :samp:`idle`
+    * - **idle**
       - Integer;
         current idle app processes.
 


### PR DESCRIPTION
Updates the docs to follow the NGINX style guide:

- Use **bold** to reference files, flags, commands (outside direct CLI instructions) instead of `inline code`
- Sentence case for titles instead of Title Case
