### PR TITLE
Copy files from deploy/_downloads subdirectories into _downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ EXCLUDE = \
 
 site: $(BUILDDIR)
 	@$(SPHINX) -E -b nxt_html source "$(BUILDDIR)"
+# Note: copy files in _downloads/<HASH>/* to _downloads/* to maintain
+# the previous webroot structure for use in internal tests.
+	cp $(BUILDDIR)/_downloads/*/* $(BUILDDIR)/_downloads
 
 $(BUILDDIR):
 	mkdir "$(BUILDDIR)"


### PR DESCRIPTION
These files are guaranteed to have unique filenames because they originate from source/downloads together.

The end result:
```
 tree -lh deploy/_downloads
[ 640]  deploy/_downloads
├── [  96]  077feed4aa66df9c8eba6520fdfcae65
│   └── [1.3K]  Dockerfile.php.txt
├── [  96]  55f3fadb10a1bec1c359757ae72cb998
│   └── [2.5K]  Dockerfile.go.txt
├── [  96]  57c3dbaa35e8622ad7cfc7dd1b281c01
│   └── [1.9K]  Dockerfile.ruby.txt
├── [  96]  626b50fd97c76a7215539b7bd884cf2c
│   └── [1.8K]  grafana.patch
├── [  96]  8b892abde1148c9ef4f41e16953cd590
│   └── [1.6K]  Dockerfile.python.txt
├── [2.5K]  Dockerfile.go.txt
├── [1.5K]  Dockerfile.java.txt
├── [1.9K]  Dockerfile.nodejs.txt
├── [1.9K]  Dockerfile.perl.txt
├── [1.3K]  Dockerfile.php.txt
├── [1.6K]  Dockerfile.python.txt
├── [1.9K]  Dockerfile.ruby.txt
├── [  96]  b16e6c96d59a63357f36a3f0c11bf14c
│   └── [6.6K]  unit-openapi.Dockerfile
├── [  96]  b9d463a96f334c8dbf77fc013ace1ea6
│   └── [1.9K]  Dockerfile.nodejs.txt
├── [  96]  ce271af7025309218beb94578326a881
│   └── [1.9K]  Dockerfile.perl.txt
├── [  96]  ff1c18f7e9e3429b93de06ac50b4f5df
│   └── [1.5K]  Dockerfile.java.txt
├── [1.8K]  grafana.patch
└── [6.6K]  unit-openapi.Dockerfile
```