### PR TITLE
Link fixes

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -125,7 +125,7 @@ to the **main**
 
 Also, **pass** values can be
 `percent encoded
-<https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__.
+<https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__.
 For example, you can escape slashes in entity names:
 
 .. code-block:: json
@@ -860,10 +860,10 @@ define patterns to be compared to the request's properties:
    * - **arguments**
      - Arguments supplied with the request's
        `query string
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__;
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__;
        these names and value pairs are
        `percent decoded
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__,
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__,
        with plus signs
        (**+**)
        replaced by spaces.
@@ -879,14 +879,14 @@ define patterns to be compared to the request's properties:
 
    * - **headers**
      - `Header fields
-       <https://datatracker.ietf.org/doc/html/rfc9110#section-6-3>`__
+       <https://datatracker.ietf.org/doc/html/rfc9110#section-6.3>`__
        supplied with the request.
      - No
 
    * - **host**
      - **Host**
        `header field
-       <https://datatracker.ietf.org/doc/html/rfc9110#section-7-2>`__,
+       <https://datatracker.ietf.org/doc/html/rfc9110#section-7.2>`__,
        converted to lower case and normalized
        by removing the port number and the trailing period
        (if any).
@@ -900,9 +900,9 @@ define patterns to be compared to the request's properties:
 
    * - **query**
      - `Query string
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__,
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__,
        `percent decoded
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__,
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__,
        with plus signs
        (**+**)
        replaced by spaces.
@@ -924,14 +924,14 @@ define patterns to be compared to the request's properties:
      - `Request target
        <https://datatracker.ietf.org/doc/html/rfc9110#target.resource>`__,
        `percent decoded
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__
        and normalized
        by removing the
        `query string
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__
        and resolving
        `relative references
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-4-2>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-4.2>`__
        ("." and "..", "//").
      - Yes
 
@@ -1227,7 +1227,7 @@ modify this behavior:
    Argument names, non-regex string patterns in **arguments**,
    **query**, and **uri** can be
    `percent encoded
-   <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__
+   <https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__
    to mask special characters
    (**!** is **%21**, **~** is **%7E**,
    ***** is **%2A**, **%** is **%25**)
@@ -1418,7 +1418,7 @@ Address-based patterns define individual IPv4
 <https://datatracker.ietf.org/doc/html/rfc4632>`__),
 IPv6 (hexadecimal or
 `CIDR
-<https://datatracker.ietf.org/doc/html/rfc4291#section-2-3>`__),
+<https://datatracker.ietf.org/doc/html/rfc4291#section-2.3>`__),
 or any
 `UNIX domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`__
 addresses
@@ -1771,7 +1771,7 @@ There's a number of built-in variables available:
    * - **host**
      - **Host**
        `header field
-       <https://datatracker.ietf.org/doc/html/rfc9110#section-7-2>`__,
+       <https://datatracker.ietf.org/doc/html/rfc9110#section-7.2>`__,
        converted to lower case and normalized
        by removing the port number
        and the trailing period (if any).
@@ -1796,10 +1796,10 @@ There's a number of built-in variables available:
    * - **request_uri**
      - Request target
        `path
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-3>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.3>`__
        *including* the
        `query
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__,
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__,
        normalized by resolving relative path references
        ("." and "..")
        and collapsing adjacent slashes.
@@ -1825,20 +1825,20 @@ There's a number of built-in variables available:
    * - **uri**
      - Request target
        `path
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-3>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.3>`__
        *without* the `query
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-4>`__
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.4>`__
        part,
        normalized by resolving relative path references
        ("." and "..")
        and collapsing adjacent slashes.
        The value is
        `percent decoded
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-2-1>`__:
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-2.1>`__:
        Unit interpolates all percent-encoded entities
        in the request target
        `path
-       <https://datatracker.ietf.org/doc/html/rfc3986#section-3-3>`__.
+       <https://datatracker.ietf.org/doc/html/rfc3986#section-3.3>`__.
 
 These variables can be used with:
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -5375,7 +5375,7 @@ In turn, the **http** option exposes the following settings:
         made of alphanumeric characters and hyphens
         (see
         `RFC 9110
-        <https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.1-6.2>`__);
+        <https://datatracker.ietf.org/doc/html/rfc9110#section-16.3.1-6>`__);
         otherwise,
         these characters are also permitted:
         **.!#$%&'*+^_`|~**.

--- a/source/howto/laravel.rst
+++ b/source/howto/laravel.rst
@@ -14,7 +14,7 @@ To run apps based on the `Laravel <https://laravel.com>`_ framework using Unit:
 #. .. include:: ../include/howto_install_prereq.rst
 
 #. Create a |app| `project
-   <https://laravel.com/docs/installation#installation-via-composer>`__.
+   <https://laravel.com/docs/installation#creating-a-laravel-project>`__.
    For our purposes, the path is **/path/to/app/**:
 
    .. code-block:: console

--- a/source/howto/responder.rst
+++ b/source/howto/responder.rst
@@ -2,21 +2,21 @@
 .. |mod| replace:: Python 3.6+
 .. |app-pip-package| replace:: responder
 .. |app-pip-link| replace:: PIP package
-.. _app-pip-link: https://responder.kennethreitz.org/en/latest/#installing-responder
+.. _app-pip-link: https://responder.kennethreitz.org/#installing-responder
 
 #########
 Responder
 #########
 
 To run apps built with the `Responder
-<https://responder.kennethreitz.org/en/latest/#>`_ web framework using Unit:
+<https://responder.kennethreitz.org/>`_ web framework using Unit:
 
 #. .. include:: ../include/howto_install_unit.rst
 
 #. .. include:: ../include/howto_install_venv.rst
 
 #. Let's try a Unit-friendly version of a `tutorial app
-   <https://responder.kennethreitz.org/en/latest/quickstart.html#declare-a-web-service>`_,
+   <https://responder.kennethreitz.org/quickstart.html#declare-a-web-service>`_,
    saving it as **/path/to/app/asgi.py**:
 
    .. code-block:: python
@@ -35,7 +35,7 @@ To run apps built with the `Responder
 
    The **app.run()** call is omitted because **app** will be directly
    run by Unit as an ASGI `callable
-   <https://github.com/taoufik07/responder/blob/103816e27ae928d42ed850190472480124ba90e3/responder/api.py#L360>`_.
+   <https://github.com/kennethreitz/responder/blob/c6f3a7364cfa79805b0d51eea011fe34d9bd331a/responder/api.py#L501>`_.
 
 #. .. include:: ../include/howto_change_ownership.rst
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -2297,7 +2297,7 @@ Community Repositories
            # rcctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
         To install Unit from
-        `OpenBSD ports <https://openports.se/www/unit>`_,
+        `OpenBSD ports <https://pkgsrc.se/www/unit>`_,
         start by updating your port collection,
         for example:
 


### PR DESCRIPTION
Addresses many of the broken links in #80.

Notable changes include openports.se -> pkgsrc.se and an IETF link. The rest are just page anchors.