### PR TITLE
Add 404.html to replace default Netlify error page

### DIFF
--- a/source/404.html
+++ b/source/404.html
@@ -1,0 +1,7 @@
+<html>
+<head><title>404 Not Found</title></head>
+<body>
+<center><h1>404 Not Found</h1></center>
+</body>
+</html>
+

--- a/source/conf.py
+++ b/source/conf.py
@@ -19,7 +19,7 @@ html_use_index = False
 html_permalinks = True
 html_permalinks_icon = u'§'
 html_baseurl = 'https://unit.nginx.org/'
-html_extra_path = ['robots.txt', 'CHANGES.txt', 'go']
+html_extra_path = ['robots.txt', 'CHANGES.txt', 'go', '404.html']
 html_context = {
     'release_date'  : release_date,
     'author'        : author,


### PR DESCRIPTION
Netlify's default 404 page displays links to Netlify's support forums and pages. For now, we're defaulting to a plain NGINX-style 404.html.

<img width="562" alt="Screenshot 2024-02-12 at 10 07 04 AM" src="https://github.com/nginx/unit-docs/assets/667598/ab7b6637-29af-4a14-837f-2134c8c5a7f9">
