### PR TITLE
WebAssembly is an 'internal' language module

### DIFF
--- a/source/howto/modules.rst
+++ b/source/howto/modules.rst
@@ -6,11 +6,11 @@ Working With Language Modules
 
 Languages supported by Unit fall into these two categories:
 
-- :ref:`External <modules-ext>` (Go, Node.js, WebAssembly): Run outside Unit
-  with an interface layer to the native runtime.
+- :ref:`External <modules-ext>` (Go, Node.js): Run outside Unit with an
+  interface layer to the native runtime.
 
-- :ref:`Embedded <modules-emb>` (Java, Perl, PHP, Python, Ruby): Execute in
-  runtimes that Unit loads at startup.
+- :ref:`Embedded <modules-emb>` (Java, Perl, PHP, Python, Ruby, WebAssembly):
+  Execute in runtimes that Unit loads at startup.
 
 For any specific language and its version, Unit needs a language module.
 
@@ -33,13 +33,6 @@ In Node.js, Unit is supported by an :program:`npm`-hosted `package
 <installation-nodejs-package>` the package from the :program:`npm` repository;
 otherwise, :ref:`build <howto/source-modules-nodejs>` it for your version of
 Node.js using Unit's sources.
-
-For WebAssembly, Unit delegates bytecode execution to the
-`Wasmtime <https://wasmtime.dev/>`_
-runtime that is installed with the
-:ref:`unit-wasm <installation-precomp-pkgs>`
-module or during
-a :ref:`source build <source-wasm>`.
 
 .. _modules-emb:
 
@@ -67,7 +60,8 @@ to find them in your system:
 
    $ ls :nxt_ph:`/path/to/modules <Use runtime value if the default was overridden>`
 
-         java.unit.so  perl.unit.so  php.unit.so  python.unit.so  ruby.unit.so
+         java.unit.so  php.unit.so     ruby.unit.so  wasm_wasi_component.unit.so
+         perl.unit.so  python.unit.so  wasm.unit.so
 
 To clarify the module versions, check the :ref:`Unit log <troubleshooting-log>`
 to see which modules were loaded at startup:


### PR DESCRIPTION
Both the WebAssembly modules, wasm & wasm-wasi-component are internal modules. I.e they are both loaded by Unit as DSO's and run under the direct control of Unit in prototype/application processes.