### PR TITLE
Release 1.32 rewrite news doc

### DIFF
--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -131,7 +131,7 @@ CLI enhancements
 The **unitc** command line tool is a convenient way of applying and editing Unit
 configuration without constructing lengthy **curl(1)** commands or knowing where
 the control socket is located. Unit 1.32.0 includes two useful enhancements to
-**unitc** that, included in the official packages.
+**unitc** that are included in the official packages.
 
 A Docker container ID can now be specified as the configuration target.
 To access the configuration of a local Unit container, use the **docker://**
@@ -195,7 +195,7 @@ Changes in behavior and other updates
 Docker image uses **stderr**, so now you can send **access_log** to stdout
 ==========================================================================
 
-With 1.32.0 the **unit.log** file will be symlinked to the containers
+With 1.32.0 the **unit.log** file will be symlinked to the container's
 **/dev/stderr** instead of **/dev/stdout**. This will leave room for the
 *access_log* to be redirected to **/dev/stdout** and will not populate
 the Unit log messages to **stdout** which might be scraped by log collectors.

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -206,6 +206,7 @@ unit.nginx.org/download/ is now sources.nginx.org/unit/
 We have moved the location of the Unit tarballs from "unit.nginx.org/download/"
 to a new, central source archive for NGINX:
 `sources.nginx.org/unit/ <https://sources.nginx.org/unit/>`__.
+
 The old link is currently proxying to the new location, but officially
 deprecated now! Please update to the new location "sources.nginx.org/unit/".
 

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -104,7 +104,6 @@ should be logged or not.
     }
 
 In this example we don't want to log any health checks sent to Unit.
-Anything will be logged to the given file in the defined format as usual.
 As shown in our example, to get the maximum out of the newly added **if**
 option, you can combine it with our JavaScript scripting feature, but this
 is not a must.

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -206,7 +206,7 @@ unit.nginx.org/download/ is now sources.nginx.org/unit/
 We have moved the location of the Unit tarballs from "unit.nginx.org/download/"
 to a new, central source archive for NGINX:
 `sources.nginx.org/unit/ <https://sources.nginx.org/unit/>`__.
-The old link is currenlty proxying to the new location, but officially
+The old link is currently proxying to the new location, but officially
 deprecated now! Please update to the new location "sources.nginx.org/unit/".
 
 ************

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -37,7 +37,7 @@ technology preview for WebAssembly, a lot has changed an happened in the
 WebAssembly ecosystem.
 
 So we evolved and with 1.32.0, we are happy to announce the support for the
-WebAssembly Component Model using the WASI 0.2 APIs. This will open the
+WebAssembly Component Model using the WASI 0.2 APIs. This opens the
 possibilities to run Wasm Components compatible with the WASI 0.2 APIs on Unit
 without having a need to rebuild them. This is also the first Language Module
 for Unit that was driven by the Community. Special thanks to Alex Crichton
@@ -195,8 +195,8 @@ Changes in behavior and other updates
 Docker image uses **stderr**, so now you can send **access_log** to stdout
 ==========================================================================
 
-With 1.32.0 the **unit.log** file will be symlinked to the container's
-**/dev/stderr** instead of **/dev/stdout**. This will leave room for the
+With 1.32.0 the **unit.log** file is symlinked to the container's
+**/dev/stderr** instead of **/dev/stdout**. This leaves room for the
 *access_log* to be redirected to **/dev/stdout** and will not populate
 the Unit log messages to **stdout** which might be scraped by log collectors.
 

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -4,26 +4,27 @@
 Unit 1.32.0 Released
 ####################
 
-NGINX Unit is a lightweight and versatile application runtime that provides
-the essential components for your web application as a single open-source
-server: running application code (including WebAssembly),
-serving static assets, handling TLS and request routing.
 
 Unit 1.32.0 comes with a new language module for WebAssembly that supports
 the WASI 0.2 HTTP world so that WebAssembly Components implementing this
 interface can be hosted on Unit.
 
+This new language module improves upon the existing WebAssembly support. We
+recommend all users to use this new implementation for WebAssembly. We consider
+the old **unit-wasm** module deprecated now.
 
 Additionally, we are adding the following features:
 
-- Enhanced the NJS experience by making all Unit variables accessible
-  from JavaScript
+- Enhanced the :doc:`NJS experience <../../scripting>` by making all Unit variables
+  accessible from JavaScript
 
-- Added support for conditional access logging
+- Added support for
+  :ref:`conditional access logging <conditional-access-logging-news>`, to help
+  you filter the requests that are logged
 
 - Added support for changing Unit's control socket permissions
 
-- Added a new variable **request_id**
+- Added a :ref:`new variable <configuration-variables>`, **request_id**
 
 ...and much more! Keep reading to learn more about what changed since 1.31.1.
 
@@ -135,6 +136,7 @@ statistics from a Docker container:
 Note that the `yq(1) <https://github.com/mikefarah/yq#install>`__ tool is required
 for YAML format conversion.
 
+.. _conditional-access-logging-news:
 **************************
 Conditional access logging
 **************************

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -15,7 +15,7 @@ the old **unit-wasm** module deprecated now.
 
 Additionally, we are adding the following features:
 
-- Enhanced the :doc:`NJS experience <../../scripting>` by making all Unit variables
+- Enhanced the :doc:`NJS (NGINX JavaScript) experience <../../scripting>` by making all Unit variables
   accessible from JavaScript
 
 - Added support for

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -52,18 +52,19 @@ Enhanced scripting support - Use Unit-variables in NGINX JavaScript
 
 Using JavaScript in Unit's configuration unlocks almost endless opportunities.
 A simple Unit configuration can be used to decide where a request should be
-routed or rewritten to by creating the values for pass and rewrite dynamically
-inside a JavaScript function.
+routed or rewritten to by creating the values for **pass** and **rewrite**
+dynamically inside a JavaScript function.
 
 Previously JavaScript modules had access to a
 :doc:`limited set of objects and scalars <../../scripting>`. Now JavaScript has
 access to all of :ref:`Unit's variables <configuration-variables>` through
 the vars object.
 
-In the following sample configuration, we set the Cache-Control header based on
-the HTTP method. We do this by accessing the method variable as **vars.method**.
-When the method starts with a "P" (POST, PUT, PATCH), we do not want to cache
-the response. For all other methods we set a **max-age** of 3600 seconds.
+In the following sample configuration, we set the **Cache-Control** header
+based on the HTTP method. We do this by accessing the method variable as
+**vars.method**. When the method starts with a "P" (POST, PUT, PATCH),
+we do not want to cache the response. For all other methods we set a **max-age**
+of 3600 seconds.
 
 .. code-block:: json
 
@@ -173,16 +174,18 @@ Unit is now on GitHub!
 
 This release is special! Special for us and the Community! As you may have
 noticed we have moved more and more of our development and planning workloads
-from our old systems to GitHub.
+from our old systems to `GitHub <https://github.com/nginx/unit/>`__.
 
 GitHub is no longer just a read-only mirror. It now serves as the primary
-source for our source code and tests. We invite you to create issues,
-contribute through pull requests, or join our discussions. There are
-many ways to get involved with us.
+source for our source code and tests. We invite you to create
+`issues <https://github.com/nginx/unit/issues>`__, contribute through
+`pull requests <https://github.com/nginx/unit/pulls>`__, or join our
+`discussions <https://github.com/nginx/unit/discussions>`__. There are many
+ways to get involved with us.
 
 We've also fully transitioned the development and maintenance of unit.nginx.org
-to GitHub. We look forward to pull requests and issues that will improve our
-documentation.
+to the `Github unit-docs <https://github.com/nginx/unit-docs/>`__ repository.
+We look forward to pull requests and issues that will improve our documentation.
 
 *************************************
 Changes in behavior and other updates

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -122,7 +122,7 @@ is present in a request or not.
     }
 
 In this example Unit will check the existence of a Cookie named session
-and only log request including this cookie.
+and only log requests when it exists.
 
 ****************
 CLI enhancements

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -28,23 +28,6 @@ Additionally, we are adding the following features:
 
 ...and much more! Keep reading to learn more about what changed since 1.31.1.
 
-**********************
-Unit is now on GitHub!
-**********************
-
-This release is special! Special for us and the Community! As you may have
-noticed we have moved more and more of our development and planning workloads
-from our old systems to GitHub.
-
-GitHub is no longer just a read-only mirror. It now serves as the primary
-source for our source code and tests. We invite you to create issues,
-contribute through pull requests, or join our discussions. There are
-many ways to get involved with us.
-
-We've also fully transitioned the development and maintenance of unit.nginx.org
-to GitHub. We look forward to pull requests and issues that will improve our
-documentation.
-
 ************************************************************************
 WebAssembly next-level: Support for Wasm components and the WASI 0.2 API
 ************************************************************************
@@ -183,6 +166,22 @@ In this example Unit will check the existence of a Cookie named session
 and only log request including this cookie.
 
 
+**********************
+Unit is now on GitHub!
+**********************
+
+This release is special! Special for us and the Community! As you may have
+noticed we have moved more and more of our development and planning workloads
+from our old systems to GitHub.
+
+GitHub is no longer just a read-only mirror. It now serves as the primary
+source for our source code and tests. We invite you to create issues,
+contribute through pull requests, or join our discussions. There are
+many ways to get involved with us.
+
+We've also fully transitioned the development and maintenance of unit.nginx.org
+to GitHub. We look forward to pull requests and issues that will improve our
+documentation.
 
 *************************************
 Changes in behavior and other updates

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -226,3 +226,61 @@ making Unit better! With 1.32.0 we would like to send a shout out to:
 - rustedsword
 - Hippolyte Pello
 - Javier Evans
+
+**************
+Full Changelog
+**************
+
+.. code-block:: none
+
+  Changes with Unit 1.32.0                                         27 Feb 2024
+
+    *) Feature: WebAssembly Components using WASI interfaces defined in
+       wasi:http/proxy@0.2.0.
+
+    *) Feature: conditional access logging.
+
+    *) Feature: NJS variables access.
+
+    *) Feature: $request_id variable contains a string that is formed using
+       random data and can be used as a unique request identifier.
+
+    *) Feature: options to set control socket permissions.
+
+    *) Feature: Ruby arrays in response headers, improving compatibility
+       with Rack v3.0.
+
+    *) Feature: Python bytearray response bodies for ASGI applications.
+
+    *) Bugfix: router could crash while sending large files. Thanks to
+       rustedsword.
+
+    *) Bugfix: serving static files from a network filesystem could lead to
+       error.
+
+    *) Bugfix: "uidmap" and "gidmap" isolation options validation.
+
+    *) Bugfix: abstract UNIX socket name could be corrupted during
+       configuration validation. Thanks to Alejandro Colomar.
+
+    *) Bugfix: HTTP header field value encoding could be misinterpreted in
+       Python module.
+
+    *) Bugfix: Node.js http.createServer() accepts and ignores the "options"
+       argument, improving compatibility with strapi applications, among
+       others.
+
+    *) Bugfix: ServerRequest.flushHeaders() implemented in Node.js module to
+       make it compatible with Next.js.
+
+    *) Bugfix: ServerRequest.httpVersion variable format in Node.js module.
+
+    *) Bugfix: Node.js module handles standard library imports prefixed with
+       "node:", making it possible to run newer Nuxt applications, among
+       others.
+
+    *) Bugfix: Node.js tarball location changed to avoid build/install
+       errors.
+
+    *) Bugfix: Go module sets environment variables necessary for building
+       on macOS/arm64 systems.

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -9,15 +9,10 @@ the essential components for your web application as a single open-source
 server: running application code (including WebAssembly),
 serving static assets, handling TLS and request routing.
 
-Unit 1.31.0 introduced a Technology Preview of a WebAssembly language module
-and an SDK for C and Rust, helping developers build and run web applications
-compiled to Wasm. Although effective, we recognized that a custom low-level
-ABI on the host side and a developer SDK for server-side WebAssembly marked
-not the conclusion, but a significant milestone in our journey.
-
 Unit 1.32.0 comes with a new language module for WebAssembly that supports
 the WASI 0.2 HTTP world so that WebAssembly Components implementing this
-Interface can be hosted on Unit.
+interface can be hosted on Unit.
+
 
 Additionally, we are adding the following features:
 
@@ -193,6 +188,7 @@ Changes in behavior and other updates
 
 - Docker image uses **stderr** (was **stdout**) so now you can send **access_log** to stdout.
 - Node JS Language Module enhancements
+-
 
 ************
 Wall of fame

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -43,8 +43,8 @@ without having a need to rebuild them. This is also the first Language Module
 for Unit that was driven by the Community. Special thanks to Alex Crichton
 for the contribution!
 
-You can find out more about this in our Blog post: WebAssembly Next-Level:
-Support for Wasm Components
+We are preparing a blog post where we will dive deeper into the details of the
+new WebAssembly language module. Stay tuned!
 
 *******************************************************************
 Enhanced scripting support - Use Unit-variables in NGINX JavaScript
@@ -76,48 +76,6 @@ the response. For all other methods we set a **max-age** of 3600 seconds.
          }
     }
 
-****************
-CLI enhancements
-****************
-
-The **unitc** command line tool is a convenient way of applying and editing Unit
-configuration without constructing lengthy **curl(1)** commands or knowing where
-the control socket is located. Unit 1.32.0 includes two useful enhancements to
-**unitc** that, included in the official packages.
-
-A Docker container ID can now be specified as the configuration target.
-To access the configuration of a local Unit container, use the **docker://**
-scheme to specify the container ID or name.
-
-It is now also possible to convert Unit's configuration to and from YAML.
-This can be convenient when a more compact format is desirable, such as when
-storing it in a source control system. YAML format also provides an elegant way
-of displaying Unit's usage statistics without the noise" of JSON.
-
-Let's combine these two enhancements to display a compact form of Unit's usage
-statistics from a Docker container:
-
-.. code-block:: bash
-
-    $ unitc docker://f4f3d9e918e6 /status --format YAML
-    connections:
-      accepted: 1067
-      active: 13
-      idle: 4
-      closed: 1050
-    requests:
-      total: 1307
-    applications:
-      my_app:
-         processes:
-            running: 14
-            starting: 0
-            idle: 4
-         requests:
-            active: 10
-
-Note that the `yq(1) <https://github.com/mikefarah/yq#install>`__ tool is required
-for YAML format conversion.
 
 .. _conditional-access-logging-news:
 **************************
@@ -164,6 +122,49 @@ is present in a request or not.
 
 In this example Unit will check the existence of a Cookie named session
 and only log request including this cookie.
+
+****************
+CLI enhancements
+****************
+
+The **unitc** command line tool is a convenient way of applying and editing Unit
+configuration without constructing lengthy **curl(1)** commands or knowing where
+the control socket is located. Unit 1.32.0 includes two useful enhancements to
+**unitc** that, included in the official packages.
+
+A Docker container ID can now be specified as the configuration target.
+To access the configuration of a local Unit container, use the **docker://**
+scheme to specify the container ID or name.
+
+It is now also possible to convert Unit's configuration to and from YAML.
+This can be convenient when a more compact format is desirable, such as when
+storing it in a source control system. YAML format also provides an elegant way
+of displaying Unit's usage statistics without the noise" of JSON.
+
+Let's combine these two enhancements to display a compact form of Unit's usage
+statistics from a Docker container:
+
+.. code-block:: bash
+
+    $ unitc docker://f4f3d9e918e6 /status --format YAML
+    connections:
+      accepted: 1067
+      active: 13
+      idle: 4
+      closed: 1050
+    requests:
+      total: 1307
+    applications:
+      my_app:
+         processes:
+            running: 14
+            starting: 0
+            idle: 4
+         requests:
+            active: 10
+
+Note that the `yq(1) <https://github.com/mikefarah/yq#install>`__ tool is required
+for YAML format conversion.
 
 
 **********************

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -29,7 +29,7 @@ Additionally, we are adding the following features:
 ...and much more! Keep reading to learn more about what changed since 1.31.1.
 
 ************************************************************************
-WebAssembly next-level: Support for Wasm components and the WASI 0.2 API
+WebAssembly: Support for Wasm components and the WASI 0.2 API
 ************************************************************************
 
 Since the release of Unit 1.31.0 in August 2023 and the announcement of our

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -188,9 +188,24 @@ and only log request including this cookie.
 Changes in behavior and other updates
 *************************************
 
-- Docker image uses **stderr** (was **stdout**) so now you can send **access_log** to stdout.
-- Node JS Language Module enhancements
--
+==========================================================================
+Docker image uses **stderr**, so now you can send **access_log** to stdout
+==========================================================================
+
+With 1.32.0 the **unit.log** file will be symlinked to the containers
+**/dev/stderr** instead of **/dev/stdout**. This will leave room for the
+*access_log* to be redirected to **/dev/stdout** and will not populate
+the Unit log messages to **stdout** which might be scraped by log collectors.
+
+=======================================================
+unit.nginx.org/download/ is now sources.nginx.org/unit/
+=======================================================
+
+We have moved the location of the Unit tarballs from "unit.nginx.org/download/"
+to a new, central source archive for NGINX:
+`sources.nginx.org/unit/ <https://sources.nginx.org/unit/>`__.
+The old link is currenlty proxying to the new location, but officially
+deprecated now! Please update to the new location "sources.nginx.org/unit/".
 
 ************
 Wall of fame

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -4,6 +4,11 @@
 Unit 1.32.0 Released
 ####################
 
+NGINX Unit is a lightweight and versatile application runtime that provides
+the essential components for your web application as a single open-source
+server: running application code (including WebAssembly),
+serving static assets, handling TLS and request routing.
+
 Unit 1.31.0 introduced a Technology Preview of a WebAssembly language module
 and an SDK for C and Rust, helping developers build and run web applications
 compiled to Wasm. Although effective, we recognized that a custom low-level


### PR DESCRIPTION
Timo

- [x] Add the Full Changelog to the release announcement as a closing statement. s

PR to address this feedback from @callahad :

At a very high level:

- [x] We need to write for an audience that doesn't know anything about Unit and and doesn't care about its history. For example, we should:
    - [x] Open with a single sentence stating what Unit is.
    - [x] Lead with WASI 0.2 / Preview 2 support _before_ we say anything about the deprecated bespoke Wasm support. Nobody cares about 1.31, they care about what 1.32 means for WebAssembly in Unit.
    - [x] Revise the feature bullets to make sense for someone who isn't on the team. E.g., "conditional access logging" and "added a new variable request_id" don't tell me anything about what this is or why I should care.
    - [x] The same applies later on (e.g., "Node JS Language Module enhancements" tells me nothing. And we had similarly notable fixes for Python and Ruby.)

- [x] Sequence the sections by order of importance. Wasm first. GitHub toward the end.

- [x] The Changes in Behavior section should talk more about the Docker change; it’s pretty significant. All logs are going to stderr instead of stdout now. If we think it’s useful to separately route access logs to stdout, we should either make that the default, or we should provide an example for how it can be done.