### PR TITLE
Switch hg to git in various places

### DIFF
--- a/source/community.rst
+++ b/source/community.rst
@@ -23,7 +23,7 @@ Contribution
 ************
 
 NGINX Unit is released under the
-`Apache 2.0 license <https://hg.nginx.org/unit/file/tip/LICENSE>`_;
+`Apache 2.0 license <https://github.com/nginx/unit/blob/master/LICENSE>`_;
 we maintain GitHub
 `repos <https://github.com/nginx>`_.
 

--- a/source/go
+++ b/source/go
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="go-import" content="unit.nginx.org hg https://hg.nginx.org/unit" />
+<meta name="go-import" content="unit.nginx.org git https://github.com/nginx/unit" />
 <meta http-equiv="refresh" content="0; url=/configuration/#modifying-go-sources" />
 </head>
 <body>

--- a/source/howto/modules.rst
+++ b/source/howto/modules.rst
@@ -115,7 +115,7 @@ adjust the command samples as needed to fit your scenario.
    For details of building Unit language modules, see the source code
    :ref:`howto <source-modules>`; it also describes building
    :doc:`Unit <source>` itself.  For more packaging examples, see our package
-   `sources <https://hg.nginx.org/unit/file/tip/pkg/>`_.
+   `sources <https://github.com/nginx/unit/tree/master/pkg>`_.
 
 ..
    Legacy anchors to preserve existing external links.

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -1724,7 +1724,7 @@ make sure to update the module as well:
 
    .. code-block:: console
 
-      $ hg clone https://hg.nginx.org/unit
+      $ git clone https://github.com/nginx/unit
       $ cd unit
       $ pwd
             :nxt_hint:`/home/user/unit <Note the path to the source code>`

--- a/source/news/2018/unit-1.4-released.rst
+++ b/source/news/2018/unit-1.4-released.rst
@@ -59,7 +59,8 @@ routing, and serving of static media assets.
 
 Please also welcome Artem Konev, who joined our team as a technical writer.  He
 has already started improving documentation on the website and updated it with
-the configuration options currently available: https://hg.nginx.org/unit-docs/
+the configuration options currently available:
+https://github.com/nginx/unit-docs/
 
 Of course, the website still leaves much to be desired, so Artem will strive to
 provide industry-grade documentation for Unit.  You are welcome to join this

--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -9,7 +9,7 @@
 
 <meta charset="utf-8" />
 {%- if pagename == "index" %}
-<meta name="go-import" content="unit.nginx.org hg https://hg.nginx.org/unit" />
+<meta name="go-import" content="unit.nginx.org git https://github.com/nginx/unit" />
 {%- endif %}
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <!-- Open Graph / Facebook -->


### PR DESCRIPTION
We have switched from internally hosted mercurial repositories to GitHub hosted git repositories as our source of truth.