### PR TITLE
Replace yum with dnf

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -3985,7 +3985,7 @@ and rebuild the app.
 
            .. code-block:: console
 
-              # yum install unit-devel
+              # dnf install unit-devel
 
    - If you installed Unit from
      :doc:`source <howto/source>`,

--- a/source/howto/modules.rst
+++ b/source/howto/modules.rst
@@ -222,14 +222,14 @@ adjust the command samples as needed to fit your scenario.
 
          .. code-block:: console
 
-            # yum install -y php-7.3.8
-            # yum install php-devel php-embedded
+            # dnf install -y php-7.3.8
+            # dnf install php-devel php-embedded
 
       #. Install RPM development tools and prepare the directory structure:
 
          .. code-block:: console
 
-            # yum install -y rpmdevtools
+            # dnf install -y rpmdevtools
             $ rpmdev-setuptree
 
       #. Create a **.spec** `file
@@ -318,4 +318,4 @@ adjust the command samples as needed to fit your scenario.
                 Wrote: /home/user/rpmbuild/RPMS/<arch>/unit-php7.3-<moduleversion>.<arch>.rpm
                 ...
 
-            # yum install -y /home/user/rpmbuild/RPMS/<arch>/unit-php7.3-<moduleversion>.<arch>.rpm
+            # dnf install -y /home/user/rpmbuild/RPMS/<arch>/unit-php7.3-<moduleversion>.<arch>.rpm

--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -49,19 +49,19 @@ revision numbers, respectively); omit the packages you won't use.
 
       .. code-block:: console
 
-         # yum install gcc make
-         # yum install golang
-         # yum install curl && \
+         # dnf install gcc make
+         # dnf install golang
+         # dnf install curl && \
                curl -sL https://rpm.nodesource.com/setup_:nxt_ph:`VERSION <Node.js 8.11 or later is supported>`.x | bash - && \
-               yum install nodejs
+               dnf install nodejs
          # npm install -g node-gyp
-         # yum install php-devel php-embedded
-         # yum install perl-devel perl-libs
-         # yum install python:nxt_ph:`X <Both Python 2 and Python 3 are supported>`-devel
-         # yum install ruby-devel rubygem-rack
-         # yum install java-:nxt_ph:`X.Y.Z <Java 8 or later is supported. Different JDKs may be used>`-openjdk-devel
-         # yum install openssl-devel
-         # yum install pcre2-devel
+         # dnf install php-devel php-embedded
+         # dnf install perl-devel perl-libs
+         # dnf install python:nxt_ph:`X <Both Python 2 and Python 3 are supported>`-devel
+         # dnf install ruby-devel rubygem-rack
+         # dnf install java-:nxt_ph:`X.Y.Z <Java 8 or later is supported. Different JDKs may be used>`-openjdk-devel
+         # dnf install openssl-devel
+         # dnf install pcre2-devel
 
 
    .. tab:: FreeBSD

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -186,8 +186,8 @@ Amazon Linux
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc17 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc17 unit-perl  \
                   unit-php unit-python39 unit-python311 unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -226,8 +226,8 @@ Amazon Linux
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
                   unit-php unit-python27 unit-python37 unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -272,8 +272,8 @@ Amazon Linux
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl unit-php  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl unit-php  \
                   unit-python27 unit-python34 unit-python35 unit-python36
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -544,8 +544,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python311 unit-ruby
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -584,8 +584,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python311 unit-ruby unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -630,8 +630,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python39 unit-python310 unit-ruby unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -676,8 +676,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python39 unit-ruby
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -722,8 +722,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python38 unit-ruby
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -769,8 +769,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11 unit-perl  \
                   unit-php unit-python27 unit-python37 unit-ruby
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -815,8 +815,8 @@ Fedora
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
                   unit-php unit-python27 unit-python37 unit-ruby
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -865,8 +865,8 @@ RHEL and derivatives
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module and build Go apps>` unit-go unit-jsc8 unit-jsc11  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module and build Go apps>` unit-go unit-jsc8 unit-jsc11  \
                   unit-perl unit-php unit-python39 unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -905,8 +905,8 @@ RHEL and derivatives
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11  \
                   unit-perl unit-php unit-python27 unit-python36 unit-python38 unit-python39 unit-wasm
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -949,8 +949,8 @@ RHEL and derivatives
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-jsc11  \
                   unit-perl unit-php unit-python27 unit-python36
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -995,8 +995,8 @@ RHEL and derivatives
 
          .. code-block:: console
 
-            # yum install unit
-            # yum install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
+            # dnf install unit
+            # dnf install :nxt_hint:`unit-devel <Required to install the Node.js module>` unit-jsc8 unit-perl  \
                   unit-php unit-python
             # systemctl restart unit  # Necessary for Unit to pick up any changes in language module setup
 
@@ -2369,7 +2369,7 @@ Community Repositories
 
       .. code-block:: console
 
-         # yum install --enablerepo=remi unit  \
+         # dnf install --enablerepo=remi unit  \
                php54-unit-php php55-unit-php php56-unit-php  \
                php70-unit-php php71-unit-php php72-unit-php php73-unit-php php74-unit-php  \
                php80-unit-php php81-unit-php php82-unit-php


### PR DESCRIPTION
yum(8) is deprecated in favour of dnf(8).

dnf replaced yum as the default package manager in Fedora 22.

RHEL 8/9 uses dnf(8) as default.