### PR TITLE
Fix Fermyon spelling in 2024 News overview

### DIFF
--- a/source/news/2024/index.rst
+++ b/source/news/2024/index.rst
@@ -6,7 +6,7 @@ News archive for the year 2024.
 
 .. nxt_news_entry::
    :author: Timo Stark
-   :description: Building Wasm Components using Feryon's Spin SDK for Rust
+   :description: Building Wasm Components using Fermyon's Spin SDK for Rust
                  and run them on NGINX Unit.
    :email: unit-owner@nginx.org
    :title: Wasm Components: Working with the Spin SDK for Rust


### PR DESCRIPTION
We have a typo in the 2024 news overview. This fixes this.