### PR TITLE
fix: njs should be lowercase

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -5627,7 +5627,7 @@ recorded. The **if** option supports a string and JavaScript code.
 If its value is empty, 0, false, null, or undefined, the logs will not be
 recorded. And the '!' as a prefix inverses the condition.
 
-Example without NJS:
+Example without njs:
 
 .. code-block:: json
 
@@ -5653,7 +5653,7 @@ We can add ! to inverse the condition.
 
 Now, all requests without a session cookie will be logged.
 
-Example with NJS and the use of a template literal:
+Example with njs and the use of a template literal:
 
 .. code-block:: json
 

--- a/source/news/2023/index.rst
+++ b/source/news/2023/index.rst
@@ -53,7 +53,7 @@ News archive for the year 2023.
 
 .. nxt_news_entry::
    :author: Unit Team
-   :description: Version 1.30.0 adds URI rewrites, expands NJS integration and
+   :description: Version 1.30.0 adds URI rewrites, expands njs integration and
                  logging capabilities, and introduces an OpenAPI specification.
    :email: unit-owner@nginx.org
    :title: Unit 1.30.0 Released
@@ -63,7 +63,7 @@ News archive for the year 2023.
 .. nxt_news_entry::
    :author: Unit Team
    :description: Version 1.29.1 addresses assorted bugs in PHP and Python app
-                 handling, NJS integration, and WebSockets.
+                 handling, njs integration, and WebSockets.
    :email: unit-owner@nginx.org
    :title: Unit 1.29.1 Released
    :date: 2023-02-28

--- a/source/news/2024/index.rst
+++ b/source/news/2024/index.rst
@@ -6,7 +6,7 @@ News archive for the year 2024.
 
 .. nxt_news_entry::
    :author: Unit Team
-   :description: Version 1.32.1 is a maintenance release that fixes bugs in the new WebAssembly Language Module and in our NJS implementation.
+   :description: Version 1.32.1 is a maintenance release that fixes bugs in the new WebAssembly Language Module and in our njs implementation.
    :email: unit-owner@nginx.org
    :title: Unit 1.32.1 Released
    :url: news/2024/unit-1.32.1-released
@@ -20,9 +20,9 @@ News archive for the year 2024.
    :title: Wasm Components: Working with the Spin SDK for Rust
    :url: news/2024/fermyon-spin-rust-sdk
    :date: 2024-03-13
-   
+
 .. nxt_news_entry::
-   :author: Timo Stark 
+   :author: Timo Stark
    :description: Part 2 of our Wasm Component Model blog series. In this Blog post you will learn
                  how to build a Rust based Wasm Component and run it on NGINX Unit.
    :email: unit-owner@nginx.org

--- a/source/news/2024/unit-1.32.0-released.rst
+++ b/source/news/2024/unit-1.32.0-released.rst
@@ -15,7 +15,7 @@ the old **unit-wasm** module deprecated now.
 
 Additionally, we have added the following features:
 
-- Enhanced the :doc:`NJS (NGINX JavaScript) experience <../../scripting>` by making all Unit variables
+- Enhanced the :doc:`njs (NGINX JavaScript) experience <../../scripting>` by making all Unit variables
   accessible from JavaScript
 
 - Added support for

--- a/source/news/2024/unit-1.32.1-released.rst
+++ b/source/news/2024/unit-1.32.1-released.rst
@@ -4,7 +4,7 @@
 Unit 1.32.1 Released
 ####################
 
-NGINX Unit 1.32.1 is a maintenance release that fixes bugs in the new WebAssembly Language Module and in our NJS implementation.
+NGINX Unit 1.32.1 is a maintenance release that fixes bugs in the new WebAssembly Language Module and in our njs implementation.
 
 ===============
 Resolved issues
@@ -27,7 +27,7 @@ As restarts will work independently of the application type, the behavior shippe
 Unit-variables in NGINX JavaScript are constantly cached
 ************************************************************
 
-In **1.32.0** we added the possibility to access all Unit variables form inside NJS.
+In **1.32.0** we added the possibility to access all Unit variables form inside njs.
 
 As reported in GitHub issue `#1169 <https://github.com/nginx/unit/issues/1169>`__ the variables were cached and would hold the wrong value, which is not how this feature should work. With version 1.32.1, we have fixed this issue.
 


### PR DESCRIPTION
Changes some instances of NJS to njs (which is the preferred way to write it)

Does not change:
- References to njs in code blocks
- Rererences to njs in changelog (as these are a copy paste of the releases changelog)


Fixes issue:  https://github.com/nginx/unit-docs/issues/132