### PR TITLE
link version to announcement

### DIFF
--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -109,7 +109,10 @@
         {%- if pagename != "index" %}
         </a>
         {%- endif %}
-        <div title="Released on {{release_date}}">v. {{version}}</div>
+        {% set release_year = release_date.split(',')[1].strip() %}
+        <div title="Released on {{release_date}}">
+         <a style="text-decoration:none; color:#cbd5e1;" href="{{ pathto('news') }}{{release_year}}/unit-{{version}}-released/">v. {{version}}</a>
+         </div>
     </h1>
     {{ toctree(maxdepth = 4) }}
 </div>


### PR DESCRIPTION
Modifies the Sphinx template to link the v. number under the Unit logo to the release announcement.

This **requires** that the announcement document follows the `unit-{{version}}-released` naming pattern.