### PR TITLE
docs: overhaul community page

### DIFF
--- a/source/community.rst
+++ b/source/community.rst
@@ -8,6 +8,10 @@
 Community
 #########
 
+************************
+Meetings and discussions
+************************
+
 We hold semi-regular meetings on Zoom
 to discuss all things related to Unit
 with our tightly knit and vibrant community.
@@ -17,41 +21,70 @@ Recorded sessions:
 - `NGINX Unit Community Call No.1
   <https://www.youtube.com/watch?v=EZbcc6D03Io>`__
 
+*************************
+Reporting bugs and issues
+*************************
 
-************
-Contribution
-************
+You can report bugs and issues on GitHub:
 
+<<<<<<< HEAD
+- You can report issues and bugs on the
+  `Issues <https://github.com/nginx/unit-docs/issues>`_
+  section of the Unit repo.
+=======
 NGINX Unit is released under the
 `Apache 2.0 license <https://github.com/nginx/unit/blob/master/LICENSE>`_;
 we maintain GitHub
 `repos <https://github.com/nginx>`_.
+>>>>>>> origin/main
 
-Please report any security-related issues
-concerning Unit to
+- If you have found a fix or want to suggest a change to the code,
+  you can open a `pull request <https://github.com/nginx/unit-docs/pulls>`_
+  on the Unit repo.
+
+You can also ask questions and discuss your suggestions for Unit by
+`subscribing <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
+to the unit@nginx.org mailing list and posting your ideas there.
+
+***************************
+Reporting security concerns
+***************************
+
+Please report any security-related issues concerning Unit to
 `security-alert@nginx.org <security-alert@nginx.org>`__.
-For our mutual convenience,
-specifically mention NGINX Unit in the subject
-and follow the
-`CVSS v3.1 <https://www.first.org/cvss/v3.1/specification-document>`__
-specification.
+For our mutual convenience, specifically mention **NGINX Unit** in the subject and follow the
+`CVSS v3.1 <https://www.first.org/cvss/v3.1/specification-document>`__.
 
-To suggest changes in code or documentation and ask questions,
-`subscribe <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
-to the unit@nginx.org mailing list
-and post your ideas there.
-Also, you can open a pull request on GitHub
-or join our
-`Slack community <https://community.nginx.org/joinslack>`__.
 
-Source code:
+************
+Contributing
+************
 
-- GitHub repository: https://github.com/nginx/unit
+We welcome contributions to the NGINX Unit project.
+If you have a feature request or a bug fix, please submit a pull request on the
+`unit repo <https://github.com/nginx/unit-docs/pulls>`_.
 
-Command-line tools:
+Please review the `Contributing Guideliens <https://github.com/nginx/unit/blob/master/CONTRIBUTING.md>`_
+before submitting your pull request.
 
-- GitHub repository: https://github.com/nginx/unit/tree/master/tools
+If you are interested in contributing to the Unit documentation,
+or find a typo or an error in the docs, you can submit a pull request on the
+`unit-docs repo <https://github.com/nginx/unit-docs/pulls>`_.
 
-Documentation:
 
-- GitHub repository: https://github.com/nginx/unit-docs
+***********
+Source Code
+***********
+The source code for the NGINX Unit project is available on GitHub.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Repository
+     - Description
+   * - `github.com/nginx/unit <https://github.com/nginx/unit>`_
+     - The repository for the NGINX Unit project source code.
+   * - `github.com/nginx/unit-docs <https://github.com/nginx/unit-docs>`_
+     - The source code for the NGINX Unit documentation you are currently reading.
+   * - `github.com/nginx/unit/tree/master/tools <https://github.com/nginx/unit/tree/master/tools>`_
+     - Source code for the NGINX Unit command-line tools.

--- a/source/community.rst
+++ b/source/community.rst
@@ -26,15 +26,11 @@ Reporting bugs and issues
 *************************
 
 - You can report issues and bugs on the
-  `Issues <https://github.com/nginx/unit-docs/issues>`_ section of the Unit repo.
+  `Issues <https://github.com/nginx/unit/issues>`_ section of the Unit repo.
 
 - If you have found a fix or want to suggest a change to the code,
-  you can open a `pull request <https://github.com/nginx/unit-docs/pulls>`_
+  you can open a `pull request <https://github.com/nginx/unit/pulls>`_
   on the Unit repo.
-
-You can also ask questions and discuss your suggestions for Unit by
-`subscribing <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
-to the unit@nginx.org mailing list and posting your ideas there.
 
 ***************************
 Reporting security concerns
@@ -50,13 +46,21 @@ Contributing
 ************
 
 We welcome contributions to the NGINX Unit project.
-If you have a feature request or a bug fix, please submit a pull request on the
-`unit repo <https://github.com/nginx/unit-docs/pulls>`_.
 
-Please review the `Contributing Guideliens <https://github.com/nginx/unit/blob/master/CONTRIBUTING.md>`_
+If you have a feature request or want to suggest an improvement, please submit a pull request on the
+`unit repo <https://github.com/nginx/unit/pulls>`_.
+
+Please review the `Contributing Guidelines <https://github.com/nginx/unit/blob/master/CONTRIBUTING.md>`_
 before submitting your pull request.
 
-If you are interested in contributing to the Unit documentation,
+You can also ask questions and discuss your suggestions for Unit:
+
+- Visiting the `Discussions section <https://github.com/nginx/unit/discussions>`_
+  of the Unit repo.
+- By `subscribing <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
+  to the unit@nginx.org mailing list and posting your ideas there.
+
+If you are interested in contributing to the **Unit documentation**,
 or find a typo or an error in the docs, you can submit a pull request on the
 `unit-docs repo <https://github.com/nginx/unit-docs/pulls>`_.
 

--- a/source/community.rst
+++ b/source/community.rst
@@ -26,7 +26,7 @@ Reporting bugs and issues
 *************************
 
 - You can report issues and bugs on the
-  `Issues <https://github.com/nginx/unit-docs/issues>`_
+  `Issues <https://github.com/nginx/unit-docs/issues>`_ section of the Unit repo.
 
 - If you have found a fix or want to suggest a change to the code,
   you can open a `pull request <https://github.com/nginx/unit-docs/pulls>`_

--- a/source/community.rst
+++ b/source/community.rst
@@ -53,7 +53,7 @@ If you have a feature request or want to suggest an improvement, please submit a
 Please review the `Contributing Guidelines <https://github.com/nginx/unit/blob/master/CONTRIBUTING.md>`_
 before submitting your pull request.
 
-You can also ask questions and discuss your suggestions for Unit:
+You can also ask questions and discuss your suggestions for Unit by:
 
 - Visiting the `Discussions section <https://github.com/nginx/unit/discussions>`_
   of the Unit repo.

--- a/source/community.rst
+++ b/source/community.rst
@@ -57,8 +57,8 @@ You can also ask questions and discuss your suggestions for Unit:
 
 - Visiting the `Discussions section <https://github.com/nginx/unit/discussions>`_
   of the Unit repo.
-- By `subscribing <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
-  to the unit@nginx.org mailing list and posting your ideas there.
+- Subscribing to the `unit@nginx.org mailing list <https://mailman.nginx.org/mailman3/lists/unit.nginx.org/>`_
+  and posting your ideas there.
 
 If you are interested in contributing to the **Unit documentation**,
 or find a typo or an error in the docs, you can submit a pull request on the

--- a/source/community.rst
+++ b/source/community.rst
@@ -25,18 +25,8 @@ Recorded sessions:
 Reporting bugs and issues
 *************************
 
-You can report bugs and issues on GitHub:
-
-<<<<<<< HEAD
 - You can report issues and bugs on the
   `Issues <https://github.com/nginx/unit-docs/issues>`_
-  section of the Unit repo.
-=======
-NGINX Unit is released under the
-`Apache 2.0 license <https://github.com/nginx/unit/blob/master/LICENSE>`_;
-we maintain GitHub
-`repos <https://github.com/nginx>`_.
->>>>>>> origin/main
 
 - If you have found a fix or want to suggest a change to the code,
   you can open a `pull request <https://github.com/nginx/unit-docs/pulls>`_
@@ -55,7 +45,6 @@ Please report any security-related issues concerning Unit to
 For our mutual convenience, specifically mention **NGINX Unit** in the subject and follow the
 `CVSS v3.1 <https://www.first.org/cvss/v3.1/specification-document>`__.
 
-
 ************
 Contributing
 ************
@@ -70,7 +59,6 @@ before submitting your pull request.
 If you are interested in contributing to the Unit documentation,
 or find a typo or an error in the docs, you can submit a pull request on the
 `unit-docs repo <https://github.com/nginx/unit-docs/pulls>`_.
-
 
 ***********
 Source Code

--- a/source/community.rst
+++ b/source/community.rst
@@ -42,8 +42,8 @@ Reporting security concerns
 
 Please report any security-related issues concerning Unit to
 `security-alert@nginx.org <security-alert@nginx.org>`__.
-For our mutual convenience, specifically mention **NGINX Unit** in the subject and follow the
-`CVSS v3.1 <https://www.first.org/cvss/v3.1/specification-document>`__.
+For our mutual convenience, specifically mention **NGINX Unit** in the subject and, if possible, provide a
+`CVSS score<https://www.first.org/cvss/>`__.
 
 ************
 Contributing


### PR DESCRIPTION
Updates the community page to split the content into sections.

Removes the link to slack and prioritizes GitHub issues as means of communication.