### PR TITLE
fix: Malformed link on the community page

### DIFF
--- a/source/community.rst
+++ b/source/community.rst
@@ -39,7 +39,7 @@ Reporting security concerns
 Please report any security-related issues concerning Unit to
 `security-alert@nginx.org <security-alert@nginx.org>`__.
 For our mutual convenience, specifically mention **NGINX Unit** in the subject and, if possible, provide a
-`CVSS score<https://www.first.org/cvss/>`__.
+`CVSS score <https://www.first.org/cvss/>`__.
 
 ************
 Contributing


### PR DESCRIPTION
fix a link in the community page.

![image](https://github.com/nginx/unit-docs/assets/78599298/380eeefa-e3ca-41d4-a922-a09e20dca8b3)

after:

![image](https://github.com/nginx/unit-docs/assets/78599298/c8cf7393-c175-4970-9eb1-b90bc207a42a)

