### PR TITLE
Include a "standard" link to the list of discussions

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -32,6 +32,7 @@ rst_prolog = """
 """.format(release_date)
 
 edit_on_github_project = 'nginx/unit-docs'
+edit_on_github_discussion = 'nginx/unit'
 edit_on_github_branch = 'master'
 
 exclude_patterns = ['include']

--- a/source/exts/github.py
+++ b/source/exts/github.py
@@ -8,7 +8,7 @@ Usage:
 
 layout.html:
     {% if edit_on_github_url %}
-        <div class="nxt_github_link">
+        <div class="nxt_edit_link">
             <a href="{{ edit_on_github_url }}"><div></div>Edit this page</a>
         </div>
     {% endif %}

--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -119,10 +119,10 @@
 <div id="content">
     {% block body %} {% endblock %}
     {% if edit_on_github_url %}
-    <div class="nxt_github_link"><a href="{{ edit_on_github_url }}"><div></div>Edit this page</a></div>
+    <div class="nxt_edit_link"><a href="{{ edit_on_github_url }}"><div></div>Edit this page</a></div>
     {% endif %}
     {% if edit_on_github_url %}
-    <div class="nxt_github_link"><a href="https://github.com/nginx/unit/discussions/"><div></div>Discuss this software</a></div>
+    <div class="nxt_discuss_link"><a href="https://github.com/nginx/unit/discussions/"><div></div>Discuss on GitHub</a></div>
     {% endif %}
     <p id="footer">
         © {{copyright}} <a href="https://www.nginx.com/">{{author}}</a>

--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -121,6 +121,9 @@
     {% if edit_on_github_url %}
     <div class="nxt_github_link"><a href="{{ edit_on_github_url }}"><div></div>Edit this page</a></div>
     {% endif %}
+    {% if edit_on_github_url %}
+    <div class="nxt_github_link"><a href="https://github.com/nginx/unit/discussions/"><div></div>Discuss this software</a></div>
+    {% endif %}
     <p id="footer">
         © {{copyright}} <a href="https://www.nginx.com/">{{author}}</a>
     </p>

--- a/source/theme/static/style.css
+++ b/source/theme/static/style.css
@@ -697,7 +697,7 @@ iframe {
     visibility: hidden;
 }
 /* GitHub link */
-.nxt_github_link {
+.nxt_discuss_link {
     position: relative;
     font-size: .9em;
     right: 0;
@@ -706,7 +706,23 @@ iframe {
     display: block;
     text-align: right;
 }
-.nxt_github_link div {
+.nxt_discuss_link div {
+    display: inline-block;
+    height: 1em;
+    margin: 0 .3em -.2em 0;
+    content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M208 352c114.9 0 208-78.8 208-176S322.9 0 208 0S0 78.8 0 176c0 38.6 14.7 74.3 39.6 103.4c-3.5 9.4-8.7 17.7-14.2 24.7c-4.8 6.2-9.7 11-13.3 14.3c-1.8 1.6-3.3 2.9-4.3 3.7c-.5 .4-.9 .7-1.1 .8l-.2 .2 0 0 0 0C1 327.2-1.4 334.4 .8 340.9S9.1 352 16 352c21.8 0 43.8-5.6 62.1-12.5c9.2-3.5 17.8-7.4 25.3-11.4C134.1 343.3 169.8 352 208 352zM448 176c0 112.3-99.1 196.9-216.5 207C255.8 457.4 336.4 512 432 512c38.2 0 73.9-8.7 104.7-23.9c7.5 4 16 7.9 25.2 11.4c18.3 6.9 40.3 12.5 62.1 12.5c6.9 0 13.1-4.5 15.2-11.1c2.1-6.6-.2-13.8-5.8-17.9l0 0 0 0-.2-.2c-.2-.2-.6-.4-1.1-.8c-1-.8-2.5-2-4.3-3.7c-3.6-3.3-8.5-8.1-13.3-14.3c-5.5-7-10.7-15.4-14.2-24.7c24.9-29 39.6-64.7 39.6-103.4c0-92.8-84.9-168.9-192.6-175.5c.4 5.1 .6 10.3 .6 15.5z"/></svg>');
+}
+/* Edit link */
+.nxt_edit_link {
+    position: relative;
+    font-size: .9em;
+    right: 0;
+    bottom: 0;
+    padding: 0;
+    display: block;
+    text-align: right;
+}
+.nxt_edit_link div {
     display: inline-block;
     height: 1em;
     margin: 0 .3em -.2em 0;
@@ -731,7 +747,9 @@ iframe {
     font-weight: bold;
 }
 @media (min-width: 45em) {
-    .nxt_github_link {
+    .nxt_edit_link {
+    }
+    .nxt_discuss_link {
     }
 }
 @media (max-width: 45em) {
@@ -766,7 +784,10 @@ iframe {
     .nxt_tabs > input.js:checked + label {
         order: 1;
     }
-    .nxt_github_link {
+    .nxt_edit_link {
+        display: none;
+    }
+    .nxt_discuss_link {
         display: none;
     }
 }
@@ -792,7 +813,10 @@ iframe {
         background: #343434;
         color: #FFFFFF;
     }
-    .nxt_github_link div {
+    .nxt_edit_link div {
+        filter: invert(1);
+    }
+    .nxt_discuss_link div {
         filter: invert(1);
     }
     #side .toctree-l2 ul:after {


### PR DESCRIPTION
I've done some hard coding. (I couldn't figure out how to set this up "properly." But since this applies to all pages, I'm not sure if that matters.)

I don't claim to know any/all PR requirements -- I'm using this as a learning experience.

Ref #150 and https://github.com/nginx/unit/pull/1299

Here's how it looks in the local build.
<img width="839" alt="Screenshot 2024-06-03 at 2 02 05 PM" src="https://github.com/nginx/unit-docs/assets/3287976/c6cf5387-fd04-437c-b1a1-b4372e2a51d8">
