### PR TITLE
docs: update njs build instructions

### DIFF
--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -119,29 +119,18 @@ revision numbers, respectively); omit the packages you won't use.
    as the Unit code.
 
    **0.8.2** is the latest version of :program:`njs` that Unit supports.
-   Make sure to check out the correct branch before configuring the binaries.
-
-   If you'd like to use `Mercurial <https://www.mercurial-scm.org/downloads>`_:
+   Make sure you are in the correct branch before configuring the binaries.
 
    .. code-block:: console
 
-      $ cd ..
-      $ hg clone https://hg.nginx.org/njs
-      $ hg update -d 10/24/2023
-
-   If you prefer `Git <https://git-scm.com/downloads>`_:
-
-   .. code-block:: console
-
-      $ cd ..
-      $ git clone https://github.com/nginx/njs
-      $ git checkout 0.8.2
+      $ git clone https://github.com/nginx/njs.git
+      $ cd njs
+      $ git checkout -b 0.8.2 0.8.2
 
    Next, configure and build the :program:`njs` binaries:
 
    .. code-block:: console
 
-      $ cd njs
       $ ./configure :nxt_hint:`--no-zlib --no-libxml2 <Ensures Unit can link against the resulting library>` && make
 
    Point to the resulting source and build directories when :ref:`configuring

--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -115,9 +115,11 @@ revision numbers, respectively); omit the packages you won't use.
    :hash: source-njs
 
    To build Unit with `njs <https://nginx.org/en/docs/njs/>`__ support,
-   download the :program:`njs` code
-   to the same parent directory
+   download the :program:`njs` code to the same parent directory
    as the Unit code.
+
+   **0.8.2** is the latest version of :program:`njs` that Unit supports.
+   Make sure to check out the correct branch before configuring the binaries.
 
    If you'd like to use `Mercurial <https://www.mercurial-scm.org/downloads>`_:
 
@@ -125,6 +127,7 @@ revision numbers, respectively); omit the packages you won't use.
 
       $ cd ..
       $ hg clone https://hg.nginx.org/njs
+      $ hg update -r 0.8.2
 
    If you prefer `Git <https://git-scm.com/downloads>`_:
 
@@ -132,6 +135,7 @@ revision numbers, respectively); omit the packages you won't use.
 
       $ cd ..
       $ git clone https://github.com/nginx/njs
+      $ git checkout 0.8.2
 
    Next, configure and build the :program:`njs` binaries:
 
@@ -166,7 +170,7 @@ revision numbers, respectively); omit the packages you won't use.
           .. warning::
              The **unit-wasm** module is deprecated.
              We recommend using **wasm-wasi-component** instead,
-             available in Unit 1.32.0 and later, which supports 
+             available in Unit 1.32.0 and later, which supports
              WebAssembly Components using standard WASI 0.2 interfaces.
 
           To build Unit with the `WebAssembly <https://webassembly.org>`__

--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -127,7 +127,7 @@ revision numbers, respectively); omit the packages you won't use.
 
       $ cd ..
       $ hg clone https://hg.nginx.org/njs
-      $ hg update -r 0.8.2
+      $ hg update -d 10/24/2023
 
    If you prefer `Git <https://git-scm.com/downloads>`_:
 

--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -127,7 +127,9 @@ revision numbers, respectively); omit the packages you won't use.
       $ cd njs
       $ git checkout -b 0.8.2 0.8.2
 
-   Next, configure and build the :program:`njs` binaries:
+   Next, configure and build the :program:`njs` binaries. Make sure to use the
+   `--no-zlib` and `--no-libxml2` options to avoid
+   conflicts with Unit's dependencies:
 
    .. code-block:: console
 


### PR DESCRIPTION
Update the `Enabling njs` steps to include changing branches to the latest supported version

![image](https://github.com/nginx/unit-docs/assets/78599298/341790d9-c838-49fd-ad5b-3f3163f01e05)
