### PR TITLE
docs: add CLI doc

### DIFF
--- a/source/contents.rst
+++ b/source/contents.rst
@@ -10,6 +10,7 @@
    scripting
    certificates
    statusapi
+   unitctl
    howto/index
    troubleshooting
    community

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -20,13 +20,15 @@ Download binaries
 
 Unitctl binaries are available for Linux (ARM64 and X64) and MacOS systems.
 
-Download the latest binaries from the `Unit GitHub releases page <https://github.com/nginx/unit/releases>`_.
+Download the latest binaries from the `Unit GitHub releases page
+<https://github.com/nginx/unit/releases>`_.
 
 *****************
 Build from source
 *****************
 
-To build unitctl from source, follow the instructions in the `unitctl repository <https://github.com/nginx/unit/tree/master/tools/unitctl>`_.
+To build unitctl from source, follow the instructions in the `unitctl repository
+<https://github.com/nginx/unit/tree/master/tools/unitctl>`_.
 
 *************
 Using unitctl

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -307,20 +307,19 @@ Edit current configuration
 ++++++++++++++++++++++++++
 
 Unitctl can fetch the configuration from a running instance of Unit and load it
-in any number of preconfigured editors on your command line using the **edit**
-command.
+in a preconfigured editor on your command line using the **edit** command.
 
-Unitctl will try to use whatever editor is configured with the **EDITOR** environment
-variable, but will default to vim, emacs, nano, vi, or pico.
+Unitctl tries to use the editor configured with the **EDITOR** environment
+variable, but defaults to vim, emacs, nano, vi, or pico if **EDITOR** is not set.
 
-To edit the current configuration, run the following command:
+To edit the current configuration, run:
 
 .. code-block:: console
 
    $ unitctl edit
 
-The configuration will be loaded into the editor, and you can make any necessary
-changes. Once you save and close the editor, you will see the following output:
+The configuration loads into the editor, allowing you to make any necessary
+changes. Once you save and close the editor, you see the following output:
 
 .. code-block:: console
 
@@ -336,11 +335,11 @@ changes. Once you save and close the editor, you will see the following output:
 Importing the configuration from a folder
 +++++++++++++++++++++++++++++++++++++++++
 
-Using the **import** command, Unitctl will parse existing configuration,
-certificates, and NJS modules stored in a directory and convert them into a
-payload to reconfigure a given Unit daemon.
+The **import** command lets Unitctl read configuration files, certificates, and
+NJS modules from a directory. Unitctl then converts these files into a payload
+to reconfigure a Unit daemon.
 
-To export the configuration, run the following command:
+To export the configuration, run:
 
 .. code-block:: console
 
@@ -354,11 +353,11 @@ To export the configuration, run the following command:
 Exporting the configuration from Unit
 +++++++++++++++++++++++++++++++++++++
 
-The **export** command will query a control API to fetch running configuration
-and NJS modules from a Unit process. Due to a technical limitation this output
-will not contain the currently stored certificate bundles. The output is saved
-as a tarball at the filename given with the **-f** argument. Standard out may be
-used with **-f -** as shown in the following examples:
+The **export** command queries a control API to fetch the running configuration
+and NJS modules from a Unit process. The output does not include the currently
+stored certificate bundles due to a technical limitation. The output is saved
+as a tarball with the filename specified by the **-f** argument. You can also
+use standard output with **-f -**, as shown in the examples below:
 
 .. code-block:: console
 
@@ -379,7 +378,7 @@ used with **-f -** as shown in the following examples:
 Wait for a socket to be available
 +++++++++++++++++++++++++++++++++
 
-All commands support waiting on unix sockets for availability:
+All commands support waiting for Unix sockets to become available:
 
 .. code-block:: console
 

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -1,0 +1,359 @@
+ .. meta::
+   :og:description: Learn how to use the Unit CLI.
+
+.. include:: include/replace.rst
+
+#############
+CLI (unitctl)
+#############
+
+Unit provides a `Rust SDK <https://github.com/nginx/unit/tree/master/tools/unitctl>`_
+to interact with its :ref:`control API <source-startup>`, and a CLI (unitctl)
+that exposes the functionality provided by the SDK.
+
+This CLI is a powerful tool that allows you to deploy, manage, and configure
+Unit in your environment.
+
+*****************
+Download binaries
+*****************
+
+We provide unitctl binaries for Linux (both ARM64 and X64) and MacOS systems.
+
+.. warning::
+
+   Links TBD
+
+*****************
+Build from source
+*****************
+
+If you would like to build unitctl from source, you can do so by following the
+instructions in the `unitctl repository
+<https://github.com/nginx/unit/tree/master/tools/unitctl>`_.
+
+*************
+Using unitctl
+*************
+
+The unitctl CLI provides a number of commands that allow you to interact with
+Unit. The following is a list of the available commands:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command
+     - Description
+
+   * - **instances**
+     - List all running Unit processes
+
+   * - **app**
+     - List and restart active applications
+
+   * - **edit**
+     - Open the current Unit configuration in the default system editor
+
+   * - **import**
+     - Import Unit configuration from a directory
+
+   * - **execute**
+     - Send a raw JSON payload to Unit
+
+   * - **status**
+     - Get the current status of the Unit
+
+   * - **listeners**
+     - List all active listeners
+
+   * - **help**
+     - Display help information for commands and options
+
+There are also a number of options that you can use with the unitctl CLI:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+
+   * - **-s, --control-socket-address <CONTROL_SOCKET_ADDRESS>**
+     - Specify a path (unix:/var/run/unit/control.sock), TCP addres with port
+       (127.0.0.1:80), or URL for Unit's control socket
+
+   * - **-w, --wait-timeout-seconds <WAIT_TIMEOUT_SECONDS>**
+     - Specify the timeout in seconds for the control socket to become available
+
+   * - **-t, --wait-max-tries <WAIT_MAX_TRIES>**
+     - Specify the maximum number of tries to connect to the control socket when
+       waiting (default: 3)
+
+   * - **-h, --help**
+     - Display help information for commands and options
+
+   * - **-v, --version**
+     - Display the version of the unitctl CLI
+
++++++++++++++++++++++++++++++++++
+List and create instances of Unit
++++++++++++++++++++++++++++++++++
+
+Running unitcl with the **instances** command will display an output similar to
+the following:
+
+.. code-block:: console
+
+   $ unitctl instances
+   No socket path provided - attempting to detect from running instance
+   unitd instance [pid: 79489, version: 1.32.0]:
+      Executable: /opt/unit/sbin/unitd
+      API control unix socket: unix:/opt/unit/control.unit.sock
+      Child processes ids: 79489, 79489
+      Runtime flags: --no-daemon
+      Configure options: --prefix=/opt/unit --user=myUser --group=myGroup --openssl
+
+The **instances** command can also be used to deploy a new instance of Unit
+using the **new** option and three arguments:
+
+1. A means to show the control API: Either a file path to open a unix socket, or
+   a TCP address with port.
+
+   - If a directory is specified the Unit container will mount this to
+     **/var/run** internally. The control socket and pid file will be accessible
+     from the host. For example: **/tmp/2**.
+   - If a TCP address is specified, the Unit container will listen on this
+     address and port. For example: **127.0.0.1:7171**.
+
+2. A path to an application. The Unit container will mount this in READ ONLY mode
+   to **/www** internally. This will allow the user to configure their Unit
+   container to expose an application stored on the host. For example: **$(pwd)**.
+
+3. An image tag. Unitctl will deploy this image, enabling you to deploy custom
+   images. For example: **unit:wasm**.
+
+.. code-block:: console
+
+   $ unitctl instances new /tmp/2 $(pwd) 'unit:wasm'
+   Pulling and starting a container from unit:wasm
+   Will mount /tmp/2 to /var/run for socket access
+   Will READ ONLY mount /home/user/unitctl to /www for application access
+   Note: Container will be on host network
+
+After the deployment is complete, you will have one Unit container running on the
+host network.
+
+++++++++++++++++++++++++++++
+List and restart runnin apps
+++++++++++++++++++++++++++++
+
+The **app** command allows you to list and restart the active applications.
+
+To list the active applications, run the following command:
+
+.. code-block:: console
+
+   $ unitctl app list
+   {
+     "wasm": {
+        "type": "wasm-wasi-component",
+        "component": "/www/wasmapp-proxy-component.wasm"
+     }
+   }
+
+To restart an application, run the following command:
+
+.. code-block:: console
+
+   $ unitctl app reload wasm
+   {
+      "success": "Ok"
+   }
+
+.. note::
+
+   This command supports operating on multiple instances of Unit at once. To do
+   this, use the **-s** option multiple times with different values:
+
+   .. code-block:: console
+
+      $ unitctl -s '127.0.0.1:8001' -s /run/nginx-unit.control.sock app list
+
+++++++++++++++++++++++
+Fetch active listeners
+++++++++++++++++++++++
+
+Unitctl can query a given control API to fetch all configured listeners.
+
+To list all active listeners, run the following command:
+
+.. code-block:: console
+
+   $ unitctl listeners
+   No socket path provided - attempting to detect from running instance
+   {
+      "127.0.0.1:8080": {
+         "pass": "routes"
+      }
+   }
+
+.. note::
+
+   This command supports operating on multiple instances of Unit at once. To do
+   this, use the **-s** option multiple times with different values:
+
+   .. code-block:: console
+
+      $ unitctl -s '127.0.0.1:8001' -s /run/nginx-unit.control.sock listeners
+
+++++++++++++++++++++++++
+Check the status of Unit
+++++++++++++++++++++++++
+
+Unitctl can query the control API to provide the status of the running Unit daemon.
+
+To get the current status of the Unit, run the following command:
+
+.. code-block:: console
+
+   $ unitctl status -t yaml
+   No socket path provided - attempting to detect from running instance
+   connections:
+      accepted: 0
+      active: 0
+      idle: 0
+      closed: 0
+   requests:
+      total: 0
+   applications: {}
+
+.. note::
+
+   This command supports operating on multiple instances of Unit at once. To do
+   this, use the **-s** option multiple times with different values:
+
+   .. code-block:: console
+
+      $ unitctl -s '127.0.0.1:8001' -s /run/nginx-unit.control.sock status
+
++++++++++++++++++++++++++++++++++++
+Send configuration payloads to Unit
++++++++++++++++++++++++++++++++++++
+
+Unitctl can accept custom request payloads and query given API endpoints with them.
+The request payload must be passed in using the **-f** flag either as a filename
+or using the **-** filename to denote the use of stdin as shown in the example below.
+
+.. code-block:: console
+
+   $ echo '{
+      "listeners": {
+         "127.0.0.1:8080": {
+               "pass": "routes"
+         }
+      },
+
+      "routes": [
+         {
+               "action": {
+                  "share": "/www/data$uri"
+               }
+         }
+      ]
+   }' | unitctl execute --http-method PUT --path /config -f -
+   {
+   "success": "Reconfiguration done."
+   }
+
+.. note::
+
+   This command supports operating on multiple instances of Unit at once. To do
+   this, use the **-s** option multiple times with different values:
+
+   .. code-block:: console
+
+      $ unitctl -s '127.0.0.1:8001' -s /run/nginx-unit.control.sock execute ...
+
+++++++++++++++++++++++++++
+Edit current configuration
+++++++++++++++++++++++++++
+
+Unitctl can fetch the configuration from a running instance of Unit and load it
+in any number of preconfigured editors on your command line.
+
+Unitctl will try to use whatever editor is configured with the **EDITOR** environment
+variable, but will default to vim, emacs, nano, vi, or pico.
+
+To edit the current configuration, run the following command:
+
+.. code-block:: console
+
+   $ unitctl edit
+
+The configuration will be loaded into the editor, and you can make any necessary
+changes. Once you save and close the editor, you will see the following output:
+
+.. code-block:: console
+
+   {
+   "success": "Reconfiguration done."
+   }
+
+.. note::
+
+   This command does not support operating on multiple instances of Unit at once.
+
++++++++++++++++++++++++++++++++++++++++++
+Importing the configuration from a folder
++++++++++++++++++++++++++++++++++++++++++
+
+Unitctl will parse existing configuration, certificates, and NJS modules stored
+in a directory and convert them into a payload to reconfigure a given Unit daemon.
+
+To export the configuration, run the following command:
+
+.. code-block:: console
+
+   $ unitctl import /opt/unit/config
+   Imported /opt/unit/config/certificates/snake.pem -> /certificates/snake.pem
+   Imported /opt/unit/config/hello.js -> /js_modules/hello.js
+   Imported /opt/unit/config/put.json -> /config
+   Imported 3 files
+
++++++++++++++++++++++++++++++++++++++
+Exporting the configuration from Unit
++++++++++++++++++++++++++++++++++++++
+
+Unitctl will query a control API to fetch running configuration and NJS modules
+from a Unit process. Due to a technical limitation this output will not contain
+the currently stored certificate bundles. The output is saved as a tarball at the
+filename given with the **-f** argument. Standard out may be used with **-f -**
+as shown in the following examples:
+
+.. code-block:: console
+
+   $ unitctl export -f config.tar
+   $ unitctl export -f -
+   $ unitctl export -f - | tar xf - config.json
+   $ unitctl export -f - > config.tar
+
+.. warning::
+
+   The exported configuration omits certificates.
+
+.. note::
+
+   This command does not support operating on multiple instances of Unit at once.
+
++++++++++++++++++++++++++++++++++
+Wait for a socket to be available
++++++++++++++++++++++++++++++++++
+
+All commands support waiting on unix sockets for availability:
+
+.. code-block:: console
+
+   $ unitctl --wait-timeout-seconds=3 --wait-max-tries=4 import /opt/unit/config`
+   Waiting for 3s control socket to be available try 2/4...
+   Waiting for 3s control socket to be available try 3/4...
+   Waiting for 3s control socket to be available try 4/4...
+   Timeout waiting for unit to start has been exceeded

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -20,9 +20,8 @@ Download binaries
 
 We provide unitctl binaries for Linux (both ARM64 and X64) and MacOS systems.
 
-.. warning::
-
-   Links TBD
+You can find the latest binaries on the `Unit GitHub releases page
+<https://github.com/nginx/unit/releases>`_
 
 *****************
 Build from source
@@ -53,6 +52,10 @@ Unit. The following is a list of the available commands:
 
    * - **edit**
      - Open the current Unit configuration in the default system editor
+
+   * - **export**
+     - Export the current Unit configuration (excluding certificates) to a
+       tarball
 
    * - **import**
      - Import Unit configuration from a directory
@@ -98,6 +101,20 @@ There are also a number of options that you can use with the unitctl CLI:
 List and create instances of Unit
 +++++++++++++++++++++++++++++++++
 
+The **instances** command allows you to list all running Unit processes and
+deploy new instances of Unit.
+
+The **instances** command has the following options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+
+   * - **new**
+     - Deploy a new instance of Unit
+
 Running unitcl with the **instances** command will display an output similar to
 the following:
 
@@ -142,11 +159,25 @@ using the **new** option and three arguments:
 After the deployment is complete, you will have one Unit container running on the
 host network.
 
-++++++++++++++++++++++++++++
-List and restart runnin apps
-++++++++++++++++++++++++++++
++++++++++++++++++++++++++++++
+List and restart running apps
++++++++++++++++++++++++++++++
 
 The **app** command allows you to list and restart the active applications.
+
+The **app** command has the following options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+
+   * - **list**
+     - List all active applications
+
+   * - **reload <APP_NAME>**
+     - Restart the specified application
 
 To list the active applications, run the following command:
 
@@ -209,7 +240,8 @@ To list all active listeners, run the following command:
 Check the status of Unit
 ++++++++++++++++++++++++
 
-Unitctl can query the control API to provide the status of the running Unit daemon.
+Unitctl can query the control API to provide the **status** of the running Unit
+daemon.
 
 To get the current status of the Unit, run the following command:
 
@@ -239,9 +271,10 @@ To get the current status of the Unit, run the following command:
 Send configuration payloads to Unit
 +++++++++++++++++++++++++++++++++++
 
-Unitctl can accept custom request payloads and query given API endpoints with them.
-The request payload must be passed in using the **-f** flag either as a filename
-or using the **-** filename to denote the use of stdin as shown in the example below.
+Using the **execute** command, Unitctl can accept custom request payloads and
+query given API endpoints with them. The request payload must be passed in using
+the **-f** flag either as a filename or using the **-** filename to denote the
+use of stdin as shown in the example below.
 
 .. code-block:: console
 
@@ -278,7 +311,8 @@ Edit current configuration
 ++++++++++++++++++++++++++
 
 Unitctl can fetch the configuration from a running instance of Unit and load it
-in any number of preconfigured editors on your command line.
+in any number of preconfigured editors on your command line using the **edit**
+command.
 
 Unitctl will try to use whatever editor is configured with the **EDITOR** environment
 variable, but will default to vim, emacs, nano, vi, or pico.
@@ -306,8 +340,9 @@ changes. Once you save and close the editor, you will see the following output:
 Importing the configuration from a folder
 +++++++++++++++++++++++++++++++++++++++++
 
-Unitctl will parse existing configuration, certificates, and NJS modules stored
-in a directory and convert them into a payload to reconfigure a given Unit daemon.
+Using the **import** command, Unitctl will parse existing configuration,
+certificates, and NJS modules stored in a directory and convert them into a
+payload to reconfigure a given Unit daemon.
 
 To export the configuration, run the following command:
 
@@ -323,11 +358,11 @@ To export the configuration, run the following command:
 Exporting the configuration from Unit
 +++++++++++++++++++++++++++++++++++++
 
-Unitctl will query a control API to fetch running configuration and NJS modules
-from a Unit process. Due to a technical limitation this output will not contain
-the currently stored certificate bundles. The output is saved as a tarball at the
-filename given with the **-f** argument. Standard out may be used with **-f -**
-as shown in the following examples:
+The **export** command will query a control API to fetch running configuration
+and NJS modules from a Unit process. Due to a technical limitation this output
+will not contain the currently stored certificate bundles. The output is saved
+as a tarball at the filename given with the **-f** argument. Standard out may be
+used with **-f -** as shown in the following examples:
 
 .. code-block:: console
 

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -265,10 +265,9 @@ To get the current status of the Unit, run the following command:
 Send configuration payloads to Unit
 +++++++++++++++++++++++++++++++++++
 
-Using the **execute** command, Unitctl can accept custom request payloads and
-query given API endpoints with them. The request payload must be passed in using
-the **-f** flag either as a filename or using the **-** filename to denote the
-use of stdin as shown in the example below.
+With the **execute** command, Unitctl can accept custom request payloads and
+query specified API endpoints with them. Use the **-f** flag to pass the request 
+payload as a filename or **-** to denote stdin, as shown in the example below.
 
 .. code-block:: console
 

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -18,7 +18,7 @@ Unit in your environment.
 Download binaries
 *****************
 
-Unitctl binaries are available for Linux (ARM64 and X64) and MacOS systems.
+Unitctl binaries are available for Linux (ARM64 and X64) and macOS systems.
 
 Download the latest binaries from the `Unit GitHub releases page
 <https://github.com/nginx/unit/releases>`_.

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -237,7 +237,7 @@ Check the status of Unit
 Unitctl can query the control API to provide the **status** of the running Unit
 daemon.
 
-To get the current status of the Unit, run the following command:
+To get the current status of the Unit, run:
 
 .. code-block:: console
 

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -126,20 +126,18 @@ Running unitcl with the **instances** command shows output similar to this:
 
 You can use the **new** option with three arguments to deploy a new instance of Unit:
 
-1. A means to show the control API: Either a file path to open a unix socket, or
-   a TCP address with port.
+1. **Control API path**: A file path for a Unix socket or a TCP address with port.
 
-   - If a directory is specified the Unit container will mount this to
-     **/var/run** internally. The control socket and pid file will be accessible
-     from the host. For example: **/tmp/2**.
-   - If a TCP address is specified, the Unit container will listen on this
-     address and port. For example: **127.0.0.1:7171**.
+   - If you specify a directory, the Unit container will mount it to **/var/run** internally. 
+     The control socket and pid file are accessible from the host. Example: **/tmp/2**.
+   - If you specify a TCP address, the Unit container will listen on this
+     address and port. Example: **127.0.0.1:7171**.
 
-2. A path to an application. The Unit container will mount this in READ ONLY mode
-   to **/www** internally. This will allow the user to configure their Unit
-   container to expose an application stored on the host. For example: **$(pwd)**.
+2. **Application path**. The Unit container will mount this path in read-only mode
+   to **/www** internally. This setup allows you to configure the Unit
+   container to expose an application stored on the host. Example: **$(pwd)**.
 
-3. An image tag. Unitctl will deploy this image, enabling you to deploy custom
+3. **Image tag**: Unitctl will deploy this image, enabling you use custom
    images. For example: **unit:wasm**.
 
 .. code-block:: console

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -8,8 +8,8 @@ CLI (unitctl)
 #############
 
 Unit provides a `Rust SDK <https://github.com/nginx/unit/tree/master/tools/unitctl>`_
-to interact with its :ref:`control API <source-startup>`, and a CLI (unitctl)
-that exposes the functionality provided by the SDK.
+to interact with its :ref:`control API <source-startup>`, and a command line
+interface (unitctl) that exposes the functionality provided by the SDK.
 
 This CLI is a powerful tool that allows you to deploy, manage, and configure
 Unit in your environment.

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -18,25 +18,21 @@ Unit in your environment.
 Download binaries
 *****************
 
-We provide unitctl binaries for Linux (both ARM64 and X64) and MacOS systems.
+Unitctl binaries are available for Linux (ARM64 and X64) and MacOS systems.
 
-You can find the latest binaries on the `Unit GitHub releases page
-<https://github.com/nginx/unit/releases>`_
+Download the latest binaries from the `Unit GitHub releases page <https://github.com/nginx/unit/releases>`_.
 
 *****************
 Build from source
 *****************
 
-If you would like to build unitctl from source, you can do so by following the
-instructions in the `unitctl repository
-<https://github.com/nginx/unit/tree/master/tools/unitctl>`_.
+To build unitctl from source, follow the instructions in the `unitctl repository <https://github.com/nginx/unit/tree/master/tools/unitctl>`_.
 
 *************
 Using unitctl
 *************
 
-The unitctl CLI provides a number of commands that allow you to interact with
-Unit. The following is a list of the available commands:
+The unitctl CLI offers several commands to interact with Unit. Here are the available commands:
 
 .. list-table::
    :header-rows: 1
@@ -64,7 +60,7 @@ Unit. The following is a list of the available commands:
      - Send a raw JSON payload to Unit
 
    * - **status**
-     - Get the current status of the Unit
+     - Get the current status of Unit
 
    * - **listeners**
      - List all active listeners
@@ -101,10 +97,10 @@ There are also a number of options that you can use with the unitctl CLI:
 List and create instances of Unit
 +++++++++++++++++++++++++++++++++
 
-The **instances** command allows you to list all running Unit processes and
+The **instances** command lets you list all running Unit processes and
 deploy new instances of Unit.
 
-The **instances** command has the following options:
+The **instances** command has the following option:
 
 .. list-table::
    :header-rows: 1
@@ -115,8 +111,7 @@ The **instances** command has the following options:
    * - **new**
      - Deploy a new instance of Unit
 
-Running unitcl with the **instances** command will display an output similar to
-the following:
+Running unitcl with the **instances** command shows output similar to this:
 
 .. code-block:: console
 
@@ -129,8 +124,7 @@ the following:
       Runtime flags: --no-daemon
       Configure options: --prefix=/opt/unit --user=myUser --group=myGroup --openssl
 
-The **instances** command can also be used to deploy a new instance of Unit
-using the **new** option and three arguments:
+You can use the **new** option with three arguments to deploy a new instance of Unit:
 
 1. A means to show the control API: Either a file path to open a unix socket, or
    a TCP address with port.

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -157,7 +157,10 @@ host network.
 List and restart running apps
 +++++++++++++++++++++++++++++
 
-The **app** command allows you to list and restart the active applications.
+The **app** command lets you list and restart active applications.
+
+Options
+-------
 
 The **app** command has the following options:
 
@@ -173,7 +176,7 @@ The **app** command has the following options:
    * - **reload <APP_NAME>**
      - Restart the specified application
 
-To list the active applications, run the following command:
+To list active applications, run:
 
 .. code-block:: console
 
@@ -185,7 +188,7 @@ To list the active applications, run the following command:
      }
    }
 
-To restart an application, run the following command:
+To restart an application, run:
 
 .. code-block:: console
 

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -209,7 +209,7 @@ Fetch active listeners
 
 Unitctl can query a given control API to fetch all configured listeners.
 
-To list all active listeners, run the following command:
+To list all active listeners, run:
 
 .. code-block:: console
 


### PR DESCRIPTION
Adds the doc for the unitctl cli

To do:
- Add the links to the binaries or remove the section
- Decide whether to add the compiling instructions here or keep them as a link to the repo
