### PR TITLE
docs: add unitctl note

### DIFF
--- a/source/news/2024/unit-1.33.0-released.rst
+++ b/source/news/2024/unit-1.33.0-released.rst
@@ -50,6 +50,12 @@ unitctl CLI tool
 :ref:`unitctl <unitctl>` is a Rust-based CLI tool that allows you to
 deploy, manage, and configure Unit in your environment.
 
+.. note::
+
+   This is a "Technical Preview" release of **unitctl**. We welcome feedback and
+   suggestions for this early access version. It is provided to test its features
+   and should not be used in production environments.
+
 ****************************
 Chunked request body support
 ****************************

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -8,6 +8,12 @@
 CLI (unitctl)
 #############
 
+.. note::
+
+   This is a "Technical Preview" release of **unitctl**. We welcome feedback and
+   suggestions for this early access version. It is provided to test its features
+   and should not be used in production environments.
+
 Unit provides a `Rust SDK <https://github.com/nginx/unit/tree/master/tools/unitctl>`_
 to interact with its :ref:`control API <source-startup>`, and a command line
 interface (unitctl) that exposes the functionality provided by the SDK.

--- a/source/unitctl.rst
+++ b/source/unitctl.rst
@@ -10,9 +10,9 @@ CLI (unitctl)
 
 .. note::
 
-   This is a "Technical Preview" release of **unitctl**. We welcome feedback and
-   suggestions for this early access version. It is provided to test its features
-   and should not be used in production environments.
+   **unitctl** is currently being provided as a "Technical Preview". We welcome
+   feedback and suggestions for this early access version. It is provided to test
+   its features and should not be used in production environments.
 
 Unit provides a `Rust SDK <https://github.com/nginx/unit/tree/master/tools/unitctl>`_
 to interact with its :ref:`control API <source-startup>`, and a command line


### PR DESCRIPTION
Adds a "early access" note to unitctl in the release notes and the unitctl doc.