### PR TITLE
Update certbot.rst - fix hitting index.html instead static file

### DIFF
--- a/source/howto/certbot.rst
+++ b/source/howto/certbot.rst
@@ -46,7 +46,7 @@ Generating Certificates
                       },
 
                       "action": {
-                          "share": ":nxt_ph:`/var/www/www.example.com$uri/ <Arbitrary directory, preferably the one used for storing static files>`"
+                          "share": ":nxt_ph:`/var/www/www.example.com$uri <Arbitrary directory, preferably the one used for storing static files>`"
                       }
                   }
               ]


### PR DESCRIPTION
When using the `unit:php8.3` Docker image and certbot if you apply the configuration specified in the documentation nginx tries to serve index.html instead of the specified file for certbot challenges:


>  "routes": [
    {
      "match": {
        "uri": "/.well-known/acme-challenge/*"
      },
      "action": {
        "share": "/var/www/acme$uri/"
      }
    },
    ...


Results in:

> nginx-1  | 2024/12/11 11:08:31.859 [debug] 55#58 *15 http static: "/var/www/acme$uri/", index: "index.html" (chroot: "")
nginx-1  | 2024/12/11 11:08:31.859 [debug] 55#58 *15 tstr query: "/var/www/acme$uri/", result: "/var/www/acme/.well-known/acme-challenge/L_rKHzm-7qkPD6pxZoSQx4F2Y87lNCpLJukMmdlmfqI/"
nginx-1  | 2024/12/11 11:08:31.860 [debug] 55#58 *15 open("/var/www/acme/.well-known/acme-challenge/L_rKHzm-7qkPD6pxZoSQx4F2Y87lNCpLJukMmdlmfqI/index.html", 0x800, 0x0): -1 err:2


As oppose to fixed configuration (removed slash at the end of "action" -> "share"):

>  "routes": [
    {
      "match": {
        "uri": "/.well-known/acme-challenge/*"
      },
      "action": {
        "share": "/var/www/acme$uri"
      }
    },
    ...


Results in:


> nginx-1              | 2024/12/11 11:02:12.234 [debug] 55#59 *15 http static: "/var/www/acme$uri", index: "index.html" (chroot: "")
nginx-1              | 2024/12/11 11:02:12.234 [debug] 55#59 *15 tstr query: "/var/www/acme$uri", result: "/var/www/acme/.well-known/acme-challenge/L_rKHzm-7qkPD6pxZoSQx4F2Y87lNCpLJukMmdlmfqI"
nginx-1              | 2024/12/11 11:02:12.234 [debug] 55#59 *15 open("/var/www/acme/.well-known/acme-challenge/L_rKHzm-7qkPD6pxZoSQx4F2Y87lNCpLJukMmdlmfqI", 0x800, 0x0): -1 err:2

