### PR TITLE
[howto/source.rst] update unitd runtime options

### DIFF
--- a/source/howto/source.rst
+++ b/source/howto/source.rst
@@ -1132,7 +1132,7 @@ counterparts, see :ref:`here <source-config-src>`.
    * - **--log pathname**
      - Pathname for Unit's :ref:`log <troubleshooting-log>`.
 
-   * - **--modules directory**
+   * - **--modulesdir directory**
      - Directory path for Unit's language :doc:`modules <modules>`
        (***.unit.so** files).
 
@@ -1140,10 +1140,10 @@ counterparts, see :ref:`here <source-config-src>`.
      - Pathname for the PID file of Unit's :program:`main` :ref:`process
        <security-apps>`.
 
-   * - **--state directory**
+   * - **--statedir directory**
      - Directory path for Unit's state storage.
 
-   * - **--tmp directory**
+   * - **--tmpdir directory**
      - Directory path for Unit's temporary file storage.
 
 Finally, to stop a running Unit:


### PR DESCRIPTION
add a `dir` suffix to the `modules`, `state` and `tmp` runtime options.