### PR TITLE
Fix 1.34.2 release notes changelog

### DIFF
--- a/source/news/2025/unit-1.34.2-released.rst
+++ b/source/news/2025/unit-1.34.2-released.rst
@@ -27,11 +27,11 @@ Full Changelog
 
 .. code-block:: none
 
-Changes with Unit 1.34.2                                         26 Feb 2025
+  Changes with Unit 1.34.2                                         26 Feb 2025
 
-    *) Security: fix missing websocket payload length validation in the Java
-       language module which could lead to Java language module processes
-       consuming excess CPU. (CVE-2025-1695).
+      *) Security: fix missing websocket payload length validation in the Java
+         language module which could lead to Java language module processes
+         consuming excess CPU. (CVE-2025-1695).
 
-    *) Bugfix: fix incorrect websocket payload length calculation in the
-       Java language module.
+      *) Bugfix: fix incorrect websocket payload length calculation in the
+         Java language module.


### PR DESCRIPTION
The changelog didn't appear in the code block due to insufficient indentation.

